### PR TITLE
fix(visualize): escape </script> in embedded NODES/EDGES so bodies with script tags don't break the page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,32 @@ jobs:
             exit 1
           fi
           echo "ok: non-conformant bundle correctly rejected"
+
+      - name: Self-test — visualizer escapes </script> in concept bodies
+        run: |
+          # Repro: a concept whose body shows an HTML/JS snippet containing a
+          # literal </script>. Without escaping, the browser's HTML tokenizer
+          # closes the inline <script> early, truncating the embedded NODES/EDGES
+          # data and breaking the whole page.
+          tmp="$(mktemp -d)"
+          cat > "$tmp/snippet.md" <<'MD'
+          ---
+          type: Reference
+          title: Snippet with a script tag
+          ---
+          Example markup a doc might contain:
+
+          ```html
+          <script src="app.js"></script>REPRO_MARKER
+          ```
+          MD
+          uv run skills/visualize/scripts/okf_visualize.py "$tmp" -o "$tmp/viz.html"
+          if grep -qF '</script>REPRO_MARKER' "$tmp/viz.html"; then
+            echo "raw </script> from a concept body leaked into the inline data script" >&2
+            exit 1
+          fi
+          grep -qF '<\/script>REPRO_MARKER' "$tmp/viz.html" || {
+            echo "expected the embedded </script> to be escaped as <\\/script>" >&2
+            exit 1
+          }
+          echo "ok: </script> inside concept bodies is safely escaped"

--- a/skills/visualize/scripts/okf_visualize.py
+++ b/skills/visualize/scripts/okf_visualize.py
@@ -29,6 +29,26 @@ FENCE = re.compile(r"^(```|~~~)")
 LINK = re.compile(r"(?<!\!)\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 
 
+def json_for_script(obj) -> str:
+    """JSON-encode ``obj`` for safe embedding inside an inline ``<script>``.
+
+    ``json.dumps`` produces valid JSON but does not escape ``</``. When a concept
+    body contains a literal ``</script>`` (common in docs that show HTML/JS
+    snippets), the browser's HTML tokenizer closes the inline ``<script>`` at
+    that point — truncating the embedded ``NODES``/``EDGES`` data and breaking the
+    whole page. Escaping ``</`` -> ``<\\/`` is valid JSON/JS yet invisible to the
+    tokenizer. ``<!--`` and the U+2028/U+2029 separators (illegal in JS string
+    literals) are neutralized for the same reason.
+    """
+    return (
+        json.dumps(obj, default=str)
+        .replace("</", "<\\/")
+        .replace("<!--", "<\\!--")
+        .replace(" ", "\\u2028")
+        .replace(" ", "\\u2029")
+    )
+
+
 def split_frontmatter(text: str):
     if not text.startswith("---"):
         return {}, text
@@ -214,7 +234,7 @@ def render(bundle: Path, out: Path, title: str | None = None, link: str | None =
     html = (HTML.replace("__NAME__", name).replace("__LINK__", src).replace("__LAYOUT__", layout)
             .replace("__OGTITLE__", og_title).replace("__OGDESC__", og_desc).replace("__OGIMAGE__", og_img)
             .replace("__N__", str(len(nodes))).replace("__E__", str(len(edges)))
-            .replace("__NODES__", json.dumps(nodes, default=str)).replace("__EDGES__", json.dumps(edges, default=str)))
+            .replace("__NODES__", json_for_script(nodes)).replace("__EDGES__", json_for_script(edges)))
     out.write_text(html, encoding="utf-8")
     return len(nodes), len(edges)
 


### PR DESCRIPTION
## The issue

`okf_visualize.py` inlines each concept's body into an inline `<script>` block:

```python
.replace("__NODES__", json.dumps(nodes, default=str))
```

`json.dumps` produces valid JSON but **does not escape `</`**. Per the HTML spec, the tokenizer ends a `<script>` element at the first `</script>` in its text — it does not understand JS/JSON string context. So if any concept body contains a literal `</script>` (very common — any doc that shows an HTML or JS snippet), the browser closes the inline data script early, the `NODES`/`EDGES` arrays are truncated mid-string, and **the whole graph fails to render** (blank page / JS error).

I hit this on a real bundle: several concepts documented markup like `<script src="..."></script>`, and the generated `viz.html` ended up with 8 literal `</script>` (only 3 legitimate) — the page was dead.

### Reproduce

```bash
tmp="$(mktemp -d)"
cat > "$tmp/snippet.md" <<'EOF'
---
type: Reference
title: Snippet
---
```html
<script src="app.js"></script>REPRO_MARKER
```
EOF
uv run skills/visualize/scripts/okf_visualize.py "$tmp" -o "$tmp/viz.html"
grep -c '</script>' "$tmp/viz.html"   # > 3  -> extra (leaked) closers break the page
```

## The fix

Add `json_for_script()` and use it for both `__NODES__` and `__EDGES__`. It escapes `</` → `<\/` (valid JSON/JS, invisible to the HTML tokenizer), plus `<!--` and the `U+2028`/`U+2029` separators (illegal in JS string literals) for good measure. This is the standard "JSON in a `<script>`" hardening.

## Test

Adds a CI self-test (in the same style as the existing non-conformant-bundle self-test) that renders a bundle whose concept body contains `</script>` and asserts it comes out escaped. It **fails on the pre-fix code** and passes after.

No change to output for bundles without script tags in bodies.
