### PR TITLE
fix: force UTF-8 stdio so validate/visualize don't crash on Windows cp1252 console

### DIFF
--- a/skills/validate/scripts/okf_validate.py
+++ b/skills/validate/scripts/okf_validate.py
@@ -173,7 +173,25 @@ def validate(bundle: Path) -> Report:
     return report
 
 
+def _force_utf8_stdio() -> None:
+    """Ensure stdout/stderr can emit the ✓/✗/— glyphs this tool prints.
+
+    Windows consoles default to cp1252, which raises UnicodeEncodeError on those
+    characters and crashes an otherwise-successful run. Reconfiguring to UTF-8
+    (Python ≥3.7) fixes it; `errors="replace"` is a belt-and-suspenders fallback
+    for any stream that still cannot encode a glyph.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
 def main() -> int:
+    _force_utf8_stdio()
     ap = argparse.ArgumentParser(description="Validate an OKF v0.1 bundle.")
     ap.add_argument("bundle", type=Path, help="path to the bundle directory")
     ap.add_argument("--strict", action="store_true", help="treat warnings as errors")

--- a/skills/visualize/scripts/okf_visualize.py
+++ b/skills/visualize/scripts/okf_visualize.py
@@ -238,7 +238,20 @@ def render(bundle: Path, out: Path, title: str | None = None, link: str | None =
     return len(nodes), len(edges)
 
 
+def _force_utf8_stdio() -> None:
+    """Reconfigure stdout/stderr to UTF-8 so status lines never crash on a
+    cp1252 (default Windows) console. `errors="replace"` is a fallback."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
 def main() -> int:
+    _force_utf8_stdio()
     ap = argparse.ArgumentParser(description="Render an OKF bundle as a self-contained HTML graph.")
     ap.add_argument("bundle", type=Path)
     ap.add_argument("-o", "--out", type=Path, default=None)


### PR DESCRIPTION
## Problem

On Windows, `okf_validate.py` crashes with `UnicodeEncodeError` on an otherwise-successful run:

```
OKF v0.1 conformance — .okf
  concepts: 17   index.md: 6   log.md: 1
Traceback (most recent call last):
  ...
  File ".../okf_validate.py", line 209, in main
    print("  \033[32m✓ conformant — no issues\033[0m")
UnicodeEncodeError: 'charmap' codec can't encode character '✓' in position 7: character maps to <undefined>
```

The conformance check itself succeeds — only the success `print()` dies. Windows consoles default to the `cp1252` code page, which cannot encode the `✓` / `✗` / `—` glyphs the CLI prints. This makes both scripts unusable on a default Windows terminal without manually setting `PYTHONUTF8=1`.

## Fix

Add a small `_force_utf8_stdio()` helper that reconfigures `stdout`/`stderr` to UTF-8 at the start of `main()` in both `okf_validate.py` and `okf_visualize.py`. Uses `sys.stdout.reconfigure` (Python ≥3.7), guarded with `getattr` + `try/except`, and `errors="replace"` as a fallback.

- No-op on Linux/macOS (streams are already UTF-8).
- `okf_visualize.py` already writes its HTML with `encoding="utf-8"`; this only covers its status prints, added for consistency.

## Test

Ran both scripts on Windows 11 (PowerShell, cp1252) **with no `PYTHONUTF8` / `PYTHONIOENCODING`** set — the exact condition that crashed before:

```
OKF v0.1 conformance — ...\.okf
  concepts: 17   index.md: 6   log.md: 1
  ✓ conformant — no issues
```

Exit 0. Visualizer likewise renders and prints cleanly.
