### PR TITLE
feat(visualize): scale guardrails — auto linear layout, batched filtering, --max-nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,39 @@ jobs:
             exit 1
           }
           echo "ok: script-breaking sequences in concept bodies are neutralized"
+
+      - name: Self-test — scale guardrails (auto linear layout, --max-nodes cap)
+        run: |
+          # Force (cose) layout freezes the page on large bundles (~32 s at 2k
+          # concepts, measured in Chrome), so above AUTO_COSE_MAX the default
+          # must fall back to a linear layout, and --max-nodes must refuse
+          # oversized bundles. Assertions are on outcomes: the note on stderr,
+          # the layout baked into the page, and the cap's non-zero exit.
+          tmp="$(mktemp -d)"
+          python3 - "$tmp" <<'PY'
+          import pathlib, sys
+          root = pathlib.Path(sys.argv[1])
+          for i in range(1200):
+              (root / f"c{i:04d}.md").write_text(
+                  f"---\ntype: Reference\ntitle: c{i}\n---\n\nSee [next](c{(i + 1) % 1200:04d}.md).\n",
+                  encoding="utf-8")
+          PY
+          uv run skills/visualize/scripts/okf_visualize.py "$tmp" -o "$tmp/viz.html" 2>"$tmp/err.txt"
+          grep -q "using the linear 'concentric' layout" "$tmp/err.txt" || {
+            echo "large bundle did not report the auto layout fallback" >&2
+            exit 1
+          }
+          grep -qF "layout:{name:'concentric'" "$tmp/viz.html" || {
+            echo "large bundle did not bake the linear fallback layout into the page" >&2
+            exit 1
+          }
+          uv run skills/visualize/scripts/okf_visualize.py "$tmp" -o "$tmp/viz2.html" --layout cose
+          grep -qF "layout:{name:'cose'" "$tmp/viz2.html" || {
+            echo "explicit --layout cose was not honored" >&2
+            exit 1
+          }
+          if uv run skills/visualize/scripts/okf_visualize.py "$tmp" -o "$tmp/viz3.html" --max-nodes 1000; then
+            echo "--max-nodes failed to refuse an oversized bundle" >&2
+            exit 1
+          fi
+          echo "ok: scale guardrails behave"

--- a/.okf/decisions/index.md
+++ b/.okf/decisions/index.md
@@ -3,3 +3,4 @@
 * [Dual distribution — plugin + skills.sh](dual-distribution.md)
 * [Ship no hooks — soft-mode upkeep](no-hooks.md)
 * [Self-contained skills via CLAUDE_SKILL_DIR](self-contained-skills.md)
+* [Scale guardrails in the visualizer](scale-guardrails.md)

--- a/.okf/decisions/scale-guardrails.md
+++ b/.okf/decisions/scale-guardrails.md
@@ -1,0 +1,37 @@
+---
+type: Decision
+title: Scale guardrails in the visualizer
+description: Default to a linear layout above 1k concepts, warn above 5k, batch and debounce filtering.
+tags: [adr, performance]
+timestamp: "2026-07-14T00:00:00Z"
+---
+
+# Context
+
+Measured in Chrome against synthetic bundles, the default force (cose) layout
+blocked the page for ~32 s at ~2k concepts (its cost grows roughly quadratically
+with node count — 20k+ extrapolates to hours), while the linear layouts loaded
+the same bundle in under 2 s. Independently of layout, a 23k-concept page took
+~27 s to load with ~650 MB of heap, and the unbatched per-keystroke filter pass
+cost ~1.8 s. Real bundles are curated and small, but nothing stopped the
+[visualizer](/components/visualizer.md) from generating a page that freezes the
+viewer's browser.
+
+# Decision
+
+Keep force as the default layout only up to 1,000 concepts and fall back to the
+linear `concentric` layout above that; an explicit `--layout` (or `?layout=`)
+always wins, and the in-page layout picker asks for confirmation before running
+force on a large graph. Above 5,000 concepts, print a warning suggesting a
+subtree render (the [visualize skill](/skills/visualize.md) accepts any
+directory). Wrap filter passes in `cy.batch()` and debounce the search box. A
+new `--max-nodes` flag lets CI refuse oversized bundles outright.
+
+# Consequences
+
+* Small bundles render exactly as before; large bundles stay responsive instead
+  of freezing the tab.
+* The guardrails are defaults, not caps — force layout remains available at any
+  size for whoever explicitly asks.
+* Legibility past ~5k concepts is still poor by nature; subtree rendering is
+  the documented path, not something the tool tries to solve.

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -28,3 +28,4 @@ described as an OKF bundle — the toolkit eating its own dog food. Render it wi
 * [Dual distribution — plugin + skills.sh](decisions/dual-distribution.md)
 * [Ship no hooks — soft-mode upkeep](decisions/no-hooks.md)
 * [Self-contained skills via CLAUDE_SKILL_DIR](decisions/self-contained-skills.md)
+* [Scale guardrails in the visualizer](decisions/scale-guardrails.md)

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,11 @@
 # Update Log
 
+## 2026-07-14
+* **Scale guardrails**: the [visualizer](/components/visualizer.md) now defaults
+  large bundles to a linear layout, warns past 5k concepts, batches/debounces
+  filtering, and gains `--max-nodes` — see the
+  [scale guardrails decision](/decisions/scale-guardrails.md).
+
 ## 2026-06-28
 * **Creation**: Documented okf-skills in its own format — the three
   [skills](/skills/okf.md), the [validator](/components/validator.md) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this plugin are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this plugin tracks the
 OKF spec version it supports.
 
+## [Unreleased]
+
+### Fixed
+- `visualize`: large bundles no longer freeze the browser. The default force
+  (cose) layout — measured at ~32 s of blocked main thread for a ~2k-concept
+  bundle, and extrapolating to hours at 20k+ — now applies only up to 1,000
+  concepts; larger bundles default to the linear `concentric` layout (explicit
+  `--layout cose` still wins, and the in-page layout picker asks before running
+  force on a large graph).
+- `visualize`: search/filter passes are wrapped in `cy.batch()` and the search
+  box is debounced (150 ms) — previously every keystroke ran an unbatched
+  style-write pass over all nodes (~1.8 s per keystroke at 23k concepts).
+
+### Added
+- `visualize`: warns above 5,000 concepts (slow page, unreadable hairball) and
+  suggests rendering a subtree; new `--max-nodes N` refuses oversized bundles
+  outright, for CI use.
+- Decision record: [scale guardrails](.okf/decisions/scale-guardrails.md).
+
 ## [0.3.4] — 2026-07-06
 
 ### Fixed

--- a/skills/visualize/SKILL.md
+++ b/skills/visualize/SKILL.md
@@ -28,5 +28,8 @@ python3 "${CLAUDE_SKILL_DIR}/scripts/okf_visualize.py" $ARGUMENTS
 ```
 
 The output defaults to `<bundle>/viz.html`. Pass `-o <path>` to write elsewhere.
+Bundles above 1,000 concepts default to the linear `concentric` layout (the
+force layout freezes the page at that size — `--layout cose` overrides), and
+`--max-nodes N` refuses oversized bundles, e.g. for CI.
 Open it in any browser; `${CLAUDE_SKILL_DIR}` resolves whether this runs as part
 of the `okf` plugin or as a standalone skills.sh skill.

--- a/skills/visualize/scripts/okf_visualize.py
+++ b/skills/visualize/scripts/okf_visualize.py
@@ -12,6 +12,10 @@ panel with its rendered markdown, outgoing links, and "Cited by" backlinks.
 Features: force/concentric/breadth-first/circle/grid layouts, per-type filter,
 free-text search, neighbour highlight, clickable cross-links and backlinks.
 
+The default layout is force (cose) up to AUTO_COSE_MAX concepts, then the linear
+concentric layout — force-directed cost grows roughly quadratically with node
+count and freezes the page on large bundles. An explicit --layout always wins.
+
 Run:  uv run okf_visualize.py <bundle-dir> [-o viz.html]
 """
 from __future__ import annotations
@@ -25,6 +29,14 @@ from pathlib import Path
 import yaml
 
 RESERVED = {"index.md", "log.md"}
+# Force (cose) layout froze the page for ~32 s at ~2k concepts (measured in
+# Chrome); the linear layouts load the same bundle in under 2 s. Past this size
+# the default switches to concentric, and the in-page layout picker asks before
+# running force. An explicit --layout (or ?layout=) still wins.
+AUTO_COSE_MAX = 1000
+# Above this the page is slow on any layout (23k concepts measured: ~27 s load,
+# ~650 MB heap) and reads as a hairball — warn and suggest rendering a subtree.
+SCALE_WARN = 5000
 FENCE = re.compile(r"^(```|~~~)")
 LINK = re.compile(r"(?<!\!)\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 
@@ -195,21 +207,24 @@ function select(id){const ele=cy.getElementById(id);if(!ele.length)return;show(i
 cy.on('tap','node',e=>select(e.target.id()));
 cy.on('tap',e=>{if(e.target===cy)cy.elements().removeClass('dim hl');});
 function applyFilter(){const q=document.getElementById('search').value.toLowerCase();const ty=document.getElementById('type').value;
- cy.nodes().forEach(n=>{const d=n.data();
+ cy.batch(()=>cy.nodes().forEach(n=>{const d=n.data();
   const m=(!q||(d.title+' '+d.type+' '+d.description+' '+(d.tags||[]).join(' ')).toLowerCase().includes(q))
         &&(!ty||d.type===ty)&&!off.has(d.type);
-  n.style('display',m?'element':'none');});}
-document.getElementById('search').oninput=applyFilter;
+  n.style('display',m?'element':'none');}));}
+let debounce;
+document.getElementById('search').oninput=()=>{clearTimeout(debounce);debounce=setTimeout(applyFilter,150);};
 document.getElementById('type').oninput=applyFilter;
 const tysel=document.getElementById('type');types.forEach(t=>{const o=document.createElement('option');o.value=t;o.textContent=t;tysel.appendChild(o);});
-document.getElementById('layout').onchange=e=>{cy.layout({name:e.target.value,animate:true,padding:40,
- nodeRepulsion:9000,idealEdgeLength:90}).run();};
+let curLayout='__LAYOUT__';
+document.getElementById('layout').onchange=e=>{const v=e.target.value;
+ if(v==='cose'&&NODES.length>__COSEMAX__&&!confirm(`force layout on ${NODES.length} concepts can freeze this tab — run anyway?`)){e.target.value=curLayout;return;}
+ curLayout=v;cy.layout({name:v,animate:true,padding:40,nodeRepulsion:9000,idealEdgeLength:90}).run();};
 document.getElementById('legend').innerHTML=types.map(t=>`<span class="chip" data-t="${esc(t)}"><span class="dot" style="background:${color[t]}"></span>${esc(t)} (${NODES.filter(n=>n.type===t).length})</span>`).join('');
 document.querySelectorAll('#legend .chip').forEach(ch=>ch.onclick=()=>{const t=ch.getAttribute('data-t');
  if(off.has(t)){off.delete(t);ch.classList.remove('off');}else{off.add(t);ch.classList.add('off');}applyFilter();});
 document.getElementById('layout').value='__LAYOUT__';
 const Q=new URLSearchParams(location.search),QL=Q.get('layout'),QS=Q.get('select');
-if(QL&&[...document.querySelectorAll('#layout option')].some(o=>o.value===QL)){document.getElementById('layout').value=QL;cy.layout({name:QL,animate:false,padding:40,nodeRepulsion:9000,idealEdgeLength:90}).run();}
+if(QL&&[...document.querySelectorAll('#layout option')].some(o=>o.value===QL)){document.getElementById('layout').value=QL;curLayout=QL;cy.layout({name:QL,animate:false,padding:40,nodeRepulsion:9000,idealEdgeLength:90}).run();}
 function fromHash(){try{const h=decodeURIComponent((location.hash||'').slice(1));if(h&&byId[h])select(h);}catch(e){}}
 addEventListener('hashchange',fromHash);
 if(QS&&byId[QS])select(QS);else fromHash();
@@ -217,8 +232,21 @@ if(QS&&byId[QS])select(QS);else fromHash();
 
 
 def render(bundle: Path, out: Path, title: str | None = None, link: str | None = None,
-           layout: str = "cose", og_image: str | None = None):
+           layout: str | None = None, og_image: str | None = None,
+           max_nodes: int | None = None):
     nodes, edges = build(bundle)
+    if max_nodes is not None and len(nodes) > max_nodes:
+        sys.exit(f"error: {len(nodes)} concepts exceeds --max-nodes {max_nodes}")
+    if layout is None:
+        layout = "cose" if len(nodes) <= AUTO_COSE_MAX else "concentric"
+        if layout != "cose":
+            print(f"note: {len(nodes)} concepts > {AUTO_COSE_MAX} — using the linear 'concentric' "
+                  "layout (force freezes the page at this size; pass --layout cose to override)",
+                  file=sys.stderr)
+    if len(nodes) > SCALE_WARN:
+        print(f"warning: {len(nodes)} concepts — the page will load slowly and read as a hairball; "
+              f"consider rendering a subtree, e.g. okf_visualize.py {bundle}/<subdir>",
+              file=sys.stderr)
     name = title or f"{bundle.resolve().parent.name}/{bundle.name}"
     src = f' <a class="src" href="{link}" target="_blank" rel="noopener">source ↗</a>' if link else ""
     aesc = lambda s: (s or "").replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
@@ -227,6 +255,7 @@ def render(bundle: Path, out: Path, title: str | None = None, link: str | None =
     og_img = (f'<meta property="og:image" content="{aesc(og_image)}">\n'
               f'<meta name="twitter:image" content="{aesc(og_image)}">') if og_image else ""
     subs = {"__NAME__": name, "__LINK__": src, "__LAYOUT__": layout,
+            "__COSEMAX__": str(AUTO_COSE_MAX),
             "__OGTITLE__": og_title, "__OGDESC__": og_desc, "__OGIMAGE__": og_img,
             "__N__": str(len(nodes)), "__E__": str(len(edges)),
             "__NODES__": json_for_script(nodes), "__EDGES__": json_for_script(edges)}
@@ -244,9 +273,12 @@ def main() -> int:
     ap.add_argument("-o", "--out", type=Path, default=None)
     ap.add_argument("-t", "--title", default=None, help="graph title (default: parent/bundle dir name)")
     ap.add_argument("-l", "--link", default=None, help="optional source URL shown in the header")
-    ap.add_argument("--layout", default="cose",
+    ap.add_argument("--layout", default=None,
                     choices=["cose", "concentric", "breadthfirst", "circle", "grid"],
-                    help="initial graph layout (default: cose)")
+                    help=f"initial graph layout (default: cose, or concentric above {AUTO_COSE_MAX} "
+                         "concepts — force layout freezes the page on large bundles)")
+    ap.add_argument("--max-nodes", type=int, default=None,
+                    help="refuse to render bundles with more concepts than this (useful in CI)")
     ap.add_argument("--og-image", default=None,
                     help="absolute URL for the social-preview image (og:image / twitter:image)")
     args = ap.parse_args()
@@ -255,7 +287,7 @@ def main() -> int:
         return 2
     out = args.out or (args.bundle / "viz.html")
     n, e = render(args.bundle, out, title=args.title, link=args.link, layout=args.layout,
-                  og_image=args.og_image)
+                  og_image=args.og_image, max_nodes=args.max_nodes)
     print(f"rendered {n} concepts, {e} links -> {out}")
     return 0
 


### PR DESCRIPTION
Fixes #4.

Fixes the browser-freeze reported in the linked issue: the visualizer now keeps its exact current behaviour for curated-size bundles, and degrades deliberately instead of accidentally past that.

## Changes

- **Auto linear layout past 1,000 concepts** — the default stays `cose` up to `AUTO_COSE_MAX` (1,000) and falls back to `concentric` above it, with a one-line note on stderr. An explicit `--layout` (or `?layout=`) always wins, and the in-page layout picker asks for confirmation before running force on a graph above the same threshold (the threshold is substituted into the page from the one Python constant).
- **Batched + debounced filtering** — `applyFilter` is wrapped in `cy.batch()`, and `#search` is debounced (150 ms) so a typed query costs one pass, not one per keystroke. Type-select and legend chips still filter immediately.
- **Scale warning + `--max-nodes`** — above `SCALE_WARN` (5,000) concepts the script warns that the page will be slow and unreadable and suggests rendering a subtree (any directory already works as a bundle root). `--max-nodes N` refuses outright, for CI.
- CI self-test asserting outcomes (fallback note, baked layout, `--layout cose` override honored, cap's non-zero exit), a changelog entry, and a `.okf/decisions/scale-guardrails.md` decision record in the dogfooded bundle.

## Measured before/after (Chrome, macOS; nav-timing `domContentLoadedEventEnd`)

| Bundle | Before (default cose) | After (auto concentric) |
|---|---|---|
| 1,920 concepts | **31.9 s** frozen tab | **2.0 s** |
| 23,000 concepts / 59k links | 27.3 s (grid; cose extrapolates to hours) | ~20 s + explicit warning |

At 23k the page is still slow and unreadable — that's what the warning + subtree guidance are for; this PR deliberately doesn't chase that scale. Search at 23k previously cost ~1.8 s **per keystroke**; it now runs one batched pass per pause.

## How tested

- `okf_validate.py --strict` passes on `.okf` (including the new decision record) and `examples/sample-bundle`.
- New CI self-test passes locally (1,200-concept bundle → fallback note + concentric baked; `--layout cose` honored; `--max-nodes 1000` refuses non-zero).
- Small-bundle behaviour unchanged: `.okf` (10 concepts) still renders with `cose` and no notes.
- Browser measurements above taken on the actual generated pages before and after the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
