### PR TITLE
docs: reframe the benchmark around what it measured, spec what it could not

### DIFF
--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,14 @@
 # Update Log
 
+## 2026-07-29
+* **Reframe**: The benchmark docs now lead with what the experiment measured —
+  answer quality, +8 points with a consistent why/where pattern — and scope the
+  token result to what a one-question-per-session design can see, which excludes
+  the cross-session repetition cost a bundle is adopted against. That experiment
+  ("What to measure next" in `benchmark/results.md`) is specced and unrun; no
+  token claim, favourable or not, until it runs. Prompted by
+  [#21](https://github.com/scaccogatto/okf-skills/issues/21).
+
 ## 2026-07-27
 * **Measurement**: Ran the first benchmark of whether a bundle helps an agent —
   12 fresh agents, this repo with and without `.okf/`, blind grading. Result:

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -8,6 +8,13 @@
   ("What to measure next" in `benchmark/results.md`) is specced and unrun; no
   token claim, favourable or not, until it runs. Prompted by
   [#21](https://github.com/scaccogatto/okf-skills/issues/21).
+* **Review**: Re-read the vendored spec's §1 intents against the benchmark
+  discourse. The tested claim — better answers, cheaper reading — is the
+  ecosystem's adoption pitch; the spec stakes v0.2 on trust of agent-written
+  corpora, which a pristine bundle never exercises. Added the trust-calibration
+  experiment (seeded rot, flat-notes arm) to `benchmark/results.md`, scoped the
+  README's selective-reading row to §8's actual promise, and named the tested
+  claim's origin in `benchmark/README.md`.
 
 ## 2026-07-27
 * **Measurement**: Ran the first benchmark of whether a bundle helps an agent —

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ Two things here you will not find elsewhere in the OKF ecosystem:
   [Google's community list](https://github.com/GoogleCloudPlatform/knowledge-catalog)
   still targeted v0.1 when we checked on 2026-07-27.
 - **A number.** We ran the experiment — one repo with and without its bundle,
-  twelve fresh agents, blind grading — and [published the result](benchmark/)
-  including the part that went against us: **the bundle did not save tokens.** What
-  it did do was answer the *why* questions the code could not.
+  twelve fresh agents, blind grading — and [published the result](benchmark/):
+  **85% of ground-truth claims answered with the bundle, 77% without**, the wins
+  exactly on the *why* questions whose answers live nowhere in the code.
+  Published with it, the part that went against us: in one-question sessions it
+  saved no tokens.
 
 ## Why knowledge-as-code (and where OKF fits)
 
@@ -81,25 +83,31 @@ and an OKF bundle for *what the team knows* — shared, structured, and shippabl
 > [**live self-graph**](https://scaccogatto.github.io/okf-skills/self.html). CI
 > validates that bundle on every push (dogfooding the conformance checker).
 
-### Does it actually help? We measured it — and it is not what you'd expect
+### Does it actually help? We measured it
 
 Twelve fresh agents, one repository in two states (with `.okf/` and without),
-six questions, blind grading. Full method, data and the bit that went wrong:
+six questions, blind grading. Full method, data and limits:
 [`benchmark/`](benchmark/).
 
 | | with `.okf/` | without |
 |---|--:|--:|
 | ground-truth claims hit | **22/26 (85%)** | 20/26 (77%) |
-| tokens spent | 257,602 | **244,805** |
+| tokens spent, one-question sessions | 257,602 | 244,805 |
 
-**The bundle did not save tokens — it cost 5% more**, which at n=1 per cell means
-*no measurable saving in either direction*. The "read three files, not three
-thousand lines" pitch did not survive contact with a repo this size.
+**What the bundle measurably improved is the answers.** It won the two questions
+asking **why** — the reasons behind a decision, which lived in an ADR and nowhere
+else — and **lost** the one asking where to change code, where the concept was a
+summary that had dropped the detail the source had. That is the shape of the
+value: the bundle earns its keep exactly where the code cannot answer.
 
-What did hold up is narrower, and it is the reason to keep a bundle: the bundle
-arm won the two questions asking **why** — the reasons behind a decision, which
-lived in an ADR and nowhere else — and **lost** the one asking where to change
-code, where the concept was a summary that had dropped the detail the source had.
+**What it did not do is save tokens within a session** — 5% more, which at n=1
+per cell is no measurable difference in either direction: on a repo this small,
+reading everything is already cheap. And the token cost a bundle is actually
+adopted against — re-deriving, or having a human re-explain, the same knowledge
+in every fresh session — accrues *across* sessions, where a one-question-per-agent
+design cannot see it, in either direction. That experiment is
+[specced but not yet run](benchmark/results.md#what-to-measure-next); until it
+runs, we claim no token number, favourable or unfavourable.
 
 So the bar this sets for your own bundle: **write down what the code cannot say.**
 A concept restating a constant measurably bought nothing. A concept recording why

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Two things here you will not find elsewhere in the OKF ecosystem:
   still targeted v0.1 when we checked on 2026-07-27.
 - **A number.** We ran the experiment — one repo with and without its bundle,
   twelve fresh agents, blind grading — and [published the result](benchmark/):
-  **85% of ground-truth claims answered with the bundle, 77% without**, the wins
-  exactly on the *why* questions whose answers live nowhere in the code.
+  **85% of ground-truth claims answered with the bundle, 77% without** — n=1 per
+  cell, so the pattern is the signal, not the total: the wins sat exactly on the
+  *why* questions whose answers live nowhere in the code.
   Published with it, the part that went against us: in one-question sessions it
   saved no tokens.
 
@@ -94,7 +95,10 @@ six questions, blind grading. Full method, data and limits:
 | ground-truth claims hit | **22/26 (85%)** | 20/26 (77%) |
 | tokens spent, one-question sessions | 257,602 | 244,805 |
 
-**What the bundle measurably improved is the answers.** It won the two questions
+**Where the bundle helped is the answers — and the pattern, not the total, is
+the signal.** At n=1 per cell, +8 points is held to the same standard as the
+token delta below: a hint, not a measurement. What the run does support is
+where the points moved: it won the two questions
 asking **why** — the reasons behind a decision, which lived in an ADR and nowhere
 else — and **lost** the one asking where to change code, where the concept was a
 summary that had dropped the detail the source had. That is the shape of the
@@ -106,11 +110,11 @@ reading everything is already cheap. And the token cost usually cited when
 adopting a bundle — re-deriving, or having a human re-explain, the same
 knowledge in every fresh session — accrues *across* sessions, where a
 one-question-per-agent design cannot see it, in either direction. That
-experiment is [specced but not yet run](benchmark/results.md#what-to-measure-next);
+experiment is [outlined but not yet run](benchmark/results.md#what-to-measure-next);
 until it runs, we claim no token number, favourable or unfavourable.
 
 So the bar this sets for your own bundle: **write down what the code cannot say.**
-A concept restating a constant measurably bought nothing. A concept recording why
+A concept restating a constant bought nothing. A concept recording why
 the constant is what it is answered a question the codebase could not.
 
 ## What's inside

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ diffable, portable home — versioned next to the code it describes. It is
 | Typed & queryable | ✅ frontmatter | ❌ prose | ❌ | ⚠️ |
 | Graph of linked concepts | ✅ | ❌ | ❌ | ⚠️ |
 | Curated & reviewed in PRs | ✅ | ✅ | ❌ implicit | ⚠️ |
-| Scales past the context window | ✅ progressive disclosure[*](benchmark/) | ❌ loaded wholesale | ⚠️ | n/a |
+| Read selectively, not wholesale | ✅ indexes + per-concept files[*](benchmark/) | ❌ loaded wholesale | ⚠️ | n/a |
 
 Use `CLAUDE.md` for *how to behave*, auto-memory for *what the agent picked up*,
 and an OKF bundle for *what the team knows* — shared, structured, and shippable.
@@ -102,12 +102,12 @@ value: the bundle earns its keep exactly where the code cannot answer.
 
 **What it did not do is save tokens within a session** — 5% more, which at n=1
 per cell is no measurable difference in either direction: on a repo this small,
-reading everything is already cheap. And the token cost a bundle is actually
-adopted against — re-deriving, or having a human re-explain, the same knowledge
-in every fresh session — accrues *across* sessions, where a one-question-per-agent
-design cannot see it, in either direction. That experiment is
-[specced but not yet run](benchmark/results.md#what-to-measure-next); until it
-runs, we claim no token number, favourable or unfavourable.
+reading everything is already cheap. And the token cost usually cited when
+adopting a bundle — re-deriving, or having a human re-explain, the same
+knowledge in every fresh session — accrues *across* sessions, where a
+one-question-per-agent design cannot see it, in either direction. That
+experiment is [specced but not yet run](benchmark/results.md#what-to-measure-next);
+until it runs, we claim no token number, favourable or unfavourable.
 
 So the bar this sets for your own bundle: **write down what the code cannot say.**
 A concept restating a constant measurably bought nothing. A concept recording why

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -3,6 +3,14 @@
 Nobody in the OKF ecosystem publishes a number. This is ours, including the
 cases where the bundle does not help — those are the interesting ones.
 
+One scoping note. The claim under test — better answers, cheaper reading — is
+the ecosystem's adoption pitch, not the spec's. The spec (§1) promises portable,
+diffable, *trustable* knowledge, and stakes v0.2 on trust of agent-written
+corpora — which this experiment never exercises, because its bundle is pristine
+(see Limits). What is measured here is the question a user asks before
+installing; the spec's own question is
+[specced as the next experiment](results.md#what-to-measure-next).
+
 ## Method
 
 **One repository, two states.** `okf-skills` at commit `e91720e`, exported twice:

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -34,6 +34,8 @@ not be described as one.
 ## What is measured
 
 - **claims hit** — of the ground-truth claims, how many the answer contains.
+- **tokens** — what the harness billed each agent for its one-question session.
+  The primary cost signal, and a within-session one by construction.
 - **files opened** — self-reported by each agent.
 - **tool calls** — self-reported by each agent.
 
@@ -57,6 +59,12 @@ experiment that deletes only one of them measures nothing.
 - **n = 1 per cell.** One agent per question per arm. Enough to see a large
   effect, not enough to resolve a small one. Treat single-question differences as
   anecdote and only the aggregate as signal.
+- **One question per session.** Each agent answers a single question and stops.
+  Whatever a bundle saves — or wastes — across sessions, by sparing the same
+  knowledge from being re-derived or re-explained every time, is invisible here
+  in either direction. The token numbers are within-session cost only; the
+  cross-session experiment is
+  [specced in results.md](results.md#what-to-measure-next).
 - **The repo documents itself in OKF**, so its bundle is unusually good. A bundle
   that has rotted would not behave like this one.
 - **Self-reported effort**, as above.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -9,7 +9,7 @@ diffable, *trustable* knowledge, and stakes v0.2 on trust of agent-written
 corpora — which this experiment never exercises, because its bundle is pristine
 (see Limits). What is measured here is the question a user asks before
 installing; the spec's own question is
-[specced as the next experiment](results.md#what-to-measure-next).
+[outlined as the next experiment](results.md#what-to-measure-next).
 
 ## Method
 
@@ -72,7 +72,7 @@ experiment that deletes only one of them measures nothing.
   knowledge from being re-derived or re-explained every time, is invisible here
   in either direction. The token numbers are within-session cost only; the
   cross-session experiment is
-  [specced in results.md](results.md#what-to-measure-next).
+  [outlined in results.md](results.md#what-to-measure-next).
 - **The repo documents itself in OKF**, so its bundle is unusually good. A bundle
   that has rotted would not behave like this one.
 - **Self-reported effort**, as above.

--- a/benchmark/results.md
+++ b/benchmark/results.md
@@ -93,9 +93,10 @@ why would not behave this way — and most repos are that kind of repo.
 disclosure buys nothing when reading everything is already cheap. The bundle's
 argument is about corpora that outgrow a context window, and this one does not.
 
-**The design stops after one question.** The token cost a bundle is usually
-adopted against is repetition: every fresh session re-derives the same knowledge
-from source, or a human re-explains it, conversation after conversation. That
+**The design stops after one question.** The token cost usually cited for
+adopting a bundle is repetition: every fresh session re-derives the same
+knowledge from source, or a human re-explains it, conversation after
+conversation. That
 cost accrues across sessions, and an experiment that ends after one question
 ends before the meter starts. Q1's control arm is the mechanism in miniature: it
 missed the no-hooks rationale, and in real use that miss does not stay an
@@ -122,7 +123,7 @@ the wrong way.
 
 ## What to measure next
 
-Two experiments would test what this one could not. Both are specced so anyone
+Three experiments would test what this one could not. All are specced so anyone
 can run them — [#21](https://github.com/scaccogatto/okf-skills/issues/21) is the
 open thread.
 
@@ -140,4 +141,18 @@ agent cannot find, the way a colleague does today. Measure cumulative tokens,
 human turns, and whether the answers stay consistent from session to session.
 That is where "the bundle keeps you from explaining the same concepts over and
 over" stops being an assertion — today it is exactly as unmeasured as
-progressive disclosure was before this file existed, and that is why it is next.
+progressive disclosure was before this file existed. One arm this experiment
+must carry: the same knowledge as a flat notes file, no frontmatter, no links.
+Without it, a win here advertises writing-things-down, not OKF.
+
+**Trust.** The experiment the spec would nominate. This one ran against a
+bundle the limits call unusually good — current, curated, verified — which is
+exactly where v0.2's machinery is idle: provenance, trust tiers and staleness
+earn their keep only when knowledge might be wrong. So seed the bundle with
+realistic rot — concepts past their `stale_after`, `status: deprecated`,
+unverified machine-written entries, one concept subtly wrong against source —
+and measure whether agents *calibrate*: discount the unverified, re-check the
+stale, refuse the deprecated. The metric flips from omissions to false
+statements: does the wrong concept's error reach the answers, and do the
+signals stop it? Q4's loss is this failure in miniature — an agent
+over-trusting a summary — and §5 exists so a consumer does not have to.

--- a/benchmark/results.md
+++ b/benchmark/results.md
@@ -3,32 +3,6 @@
 Run on 2026-07-27 against `okf-skills` at `e91720e`. Method and limits:
 [README](README.md). Questions and claim lists: [questions.md](questions.md).
 
-## Cost
-
-`tokens` is what the harness billed each agent — the honest effort number, and
-the reason the self-reported file counts below are a footnote rather than the
-headline. `files` is self-reported by each agent.
-
-| Question | tokens, with `.okf/` | tokens, without | delta | files with/without |
-|---|--:|--:|--:|--:|
-| Q1 lookup | 38,672 | 38,655 | +0.0% | 2 / 3 |
-| Q2 lookup | 33,869 | 33,899 | −0.1% | 2 / 1 |
-| Q3 cross-cutting | 39,494 | 41,051 | −3.8% | 10 / 7 |
-| Q4 change-site | 45,098 | 43,427 | +3.8% | 2 / 1 |
-| Q5 cross-cutting | 50,090 | 48,434 | +3.4% | 2 / 2 |
-| Q6 cross-cutting | 50,379 | 39,339 | +28.1% | 2 / 2 |
-| **total** | **257,602** | **244,805** | **+5.2%** | 20 / 16 |
-
-**The bundle arm cost more, not less.** 5.2% more tokens over six questions, and
-it opened more files, not fewer. At n=1 per cell that total is inside the noise —
-Q6 alone swings 28% with both arms reading the same two files — so the honest
-reading is not "the bundle costs 5% more" but **"no measurable cost saving, in
-either direction."**
-
-That is worth saying plainly, because the usual claim made for a knowledge bundle
-is that an agent reads three small files instead of three thousand lines. On this
-repo, at this size, that saving did not appear.
-
 ## Correctness
 
 Claims hit, out of the ground-truth list for each question. Graded blind.
@@ -76,9 +50,38 @@ So the shape of the finding: **a bundle earns its keep for the knowledge that ha
 no other home — decisions, rationale, the reason behind a number. For anything the
 code itself states, it is neutral at best and a detour at worst.**
 
+## Cost, within a session
+
+Each agent answers one question in a fresh session and stops, so `tokens` here
+prices a single question — what a bundle saves or wastes *across* sessions is
+invisible to this design ([What to measure next](#what-to-measure-next)).
+`tokens` is what the harness billed each agent — the honest effort number, and
+the reason the self-reported file counts below are a footnote rather than the
+headline. `files` is self-reported by each agent.
+
+| Question | tokens, with `.okf/` | tokens, without | delta | files with/without |
+|---|--:|--:|--:|--:|
+| Q1 lookup | 38,672 | 38,655 | +0.0% | 2 / 3 |
+| Q2 lookup | 33,869 | 33,899 | −0.1% | 2 / 1 |
+| Q3 cross-cutting | 39,494 | 41,051 | −3.8% | 10 / 7 |
+| Q4 change-site | 45,098 | 43,427 | +3.8% | 2 / 1 |
+| Q5 cross-cutting | 50,090 | 48,434 | +3.4% | 2 / 2 |
+| Q6 cross-cutting | 50,379 | 39,339 | +28.1% | 2 / 2 |
+| **total** | **257,602** | **244,805** | **+5.2%** | 20 / 16 |
+
+**The bundle arm cost more, not less.** 5.2% more tokens over six questions, and
+it opened more files, not fewer. At n=1 per cell that total is inside the noise —
+Q6 alone swings 28% with both arms reading the same two files — so the honest
+reading is not "the bundle costs 5% more" but **"no measurable cost saving, in
+either direction."**
+
+That is worth saying plainly, because one claim made for a knowledge bundle is
+that an agent reads three small files instead of three thousand lines. On this
+repo, at this size, within a session, that saving did not appear.
+
 ## Why the saving did not appear here
 
-Two properties of this repository, both of which weaken the bundle's case:
+Two properties of this repository, and one of this experiment's design:
 
 **The code carries its own reasoning.** The threshold in Q2 is a named constant
 with a four-line comment giving the measurement that set it. The severity rule in
@@ -90,9 +93,18 @@ why would not behave this way — and most repos are that kind of repo.
 disclosure buys nothing when reading everything is already cheap. The bundle's
 argument is about corpora that outgrow a context window, and this one does not.
 
-Neither is an argument that OKF does not work. Both are an argument that *this
-benchmark cannot see the cost effect it was built to measure*, which is a
-different and more useful thing to know than a favourable number would have been.
+**The design stops after one question.** The token cost a bundle is usually
+adopted against is repetition: every fresh session re-derives the same knowledge
+from source, or a human re-explains it, conversation after conversation. That
+cost accrues across sessions, and an experiment that ends after one question
+ends before the meter starts. Q1's control arm is the mechanism in miniature: it
+missed the no-hooks rationale, and in real use that miss does not stay an
+omission — it becomes a person supplying the rationale by hand, this session and
+again the next. Here it was graded, and the session ended.
+
+None of the three says OKF does not work. All three say *this benchmark cannot
+see the cost effect a bundle is bought for*, which is a different and more
+useful thing to know than a favourable number would have been.
 
 ## What this changes about how the bundle is pitched
 
@@ -108,9 +120,24 @@ answered a question the codebase otherwise could not.
 That is a bar for what belongs in a bundle, and it came out of a result that went
 the wrong way.
 
-## If someone repeats this
+## What to measure next
 
-The experiment worth running next is the one this repo cannot host: a corpus large
-enough that reading everything is not an option, and a codebase whose comments say
-what rather than why. That is where progressive disclosure should show up as a
-cost saving, and where six questions and n=1 would no longer be enough.
+Two experiments would test what this one could not. Both are specced so anyone
+can run them — [#21](https://github.com/scaccogatto/okf-skills/issues/21) is the
+open thread.
+
+**Scale.** The same design on the corpus this repo cannot be: large enough that
+reading everything is not an option, with comments that say what rather than
+why. That is where progressive disclosure should show up as a within-session
+saving — and where six questions at n=1 would no longer be enough.
+
+**Repetition.** The cost this design truncates. Two arms as before, but a
+*sequence* of tasks per arm with overlapping knowledge needs, run as fresh
+sessions — the way agents are actually used. In the bundle arm the knowledge
+persists in `.okf/` and every session reads it; in the control arm it is
+re-derived from source, or supplied by a scripted "user" who answers what the
+agent cannot find, the way a colleague does today. Measure cumulative tokens,
+human turns, and whether the answers stay consistent from session to session.
+That is where "the bundle keeps you from explaining the same concepts over and
+over" stops being an assertion — today it is exactly as unmeasured as
+progressive disclosure was before this file existed, and that is why it is next.

--- a/benchmark/results.md
+++ b/benchmark/results.md
@@ -115,7 +115,7 @@ this size, and says so.
 
 What it does support is narrower and more defensible: **write down what the code
 cannot say.** A concept that restates a constant is a maintenance liability that
-measurably bought nothing here. A concept that records why the constant is 1,000
+bought nothing here. A concept that records why the constant is 1,000
 answered a question the codebase otherwise could not.
 
 That is a bar for what belongs in a bundle, and it came out of a result that went
@@ -123,9 +123,9 @@ the wrong way.
 
 ## What to measure next
 
-Three experiments would test what this one could not. All are specced so anyone
-can run them — [#21](https://github.com/scaccogatto/okf-skills/issues/21) is the
-open thread.
+Three experiments would test what this one could not. Each is outlined below —
+enough to argue with, not yet a full protocol — and
+[#21](https://github.com/scaccogatto/okf-skills/issues/21) is the open thread.
 
 **Scale.** The same design on the corpus this repo cannot be: large enough that
 reading everything is not an option, with comments that say what rather than


### PR DESCRIPTION
Addresses #21, which makes two points worth separating:

1. **The docs led with the token miss, not the measured strength.** Agreed, and fixed. The experiment's actual finding is a quality result — 85% of ground-truth claims with the bundle vs 77% without, the wins exactly on the *why* questions whose answers live nowhere in the code. README and `results.md` now lead with that (correctness section first, cost second).

2. **"The bundle did not save tokens" over-claims the negative.** Also agreed, but the fix is precision, not a favourable claim. The design is one question per fresh session: the token cost a bundle is adopted against — re-deriving, or having a human re-explain, the same knowledge session after session — accrues *across* sessions, and this design cannot observe it **in either direction**. The docs now say exactly that: within-session cost was a wash on a repo this small, and the cross-session claim is unmeasured — so we make no token claim, favourable or unfavourable, until the experiment that could support one runs.

That experiment is now specced in `results.md` → **What to measure next**, alongside the scale one: two arms, a sequence of overlapping tasks as fresh sessions, control arm gets knowledge from source or from a scripted "user" the way a colleague does today; measure cumulative tokens, human turns, and answer consistency. Specced so anyone can run it — running it is what stays open on #21.

What this deliberately does **not** do is soften the published numbers. The unfavourable table is intact and still one section tall; honesty about the result is this repo's differentiator, and the issue is right that honesty also requires not letting a within-session number stand in for a cross-session claim.

Changes: `README.md` (headline bullet + benchmark section), `benchmark/results.md` (section order, cost scoped, third reason the saving could not appear, next-experiments spec), `benchmark/README.md` (tokens in *What is measured*, one-question-per-session limit), `.okf/log.md` (dated entry).

Verified: `okf_validate.py .okf --strict` clean, 52/52 tests pass, `make docs` output byte-identical (log.md is not embedded in the self-graph).