### PR TITLE
benchmark: a runnable protocol for the repetition (cross-session) experiment

### DIFF
--- a/benchmark/faq.md
+++ b/benchmark/faq.md
@@ -1,0 +1,77 @@
+# Scripted colleague — ground truth
+
+This file is the *entire* knowledge of the scripted colleague described in
+[repetition/README.md](repetition/README.md). It contains the same facts as the
+task claim lists, written the way a teammate would say them. It is committed
+before any run; wording may be tuned for delivery after the pilot, facts may
+not change.
+
+## Upkeep and enforcement
+
+There's a Stop hook that ships with the plugin — `hooks/okf-stop-check.sh` —
+but it's dormant: it does nothing unless the bundle itself opts in by putting
+`upkeep: enforced` in the frontmatter of `.okf/index.md`. It has to be in the
+frontmatter, between the two `---` lines; mentioning it elsewhere in the file
+doesn't arm it. Once armed, it blocks the agent from stopping when the tree has
+uncommitted changes but `.okf/log.md` wasn't touched, and asks for the matching
+concept update plus a dated log entry. If nothing documented actually changed,
+the agent is allowed to finish. Anyone can kill it globally with `OKF_HOOK=off`
+in their environment, whatever the bundle says.
+
+Sharp edges we accept: it looks at *any* uncommitted change, not just this
+session's, so a chronically dirty tree gets nudged every stop; and a dirty
+`log.md` left over from an earlier session keeps it quiet until committed.
+
+History: the project originally shipped *no* hooks at all, on purpose —
+always-on hooks watching every session are intrusive and can fail marketplace
+safety review. That decision was superseded by the dormant hook; the old soft
+mode still exists as a snippet, `templates/CLAUDE-okf.md`, that you paste into
+a project's `CLAUDE.md`.
+
+## Trust tiers and staleness
+
+The trust badge you see in the graph is computed when the graph is rendered —
+it is stored nowhere, deliberately: a stored tier is a stored opinion and it
+goes stale. The rule is the spec's §5.3: a concept with no `verified` entries
+is *unverified*; `verified` entries from machine actors only make it
+*machine-confirmed*; at least one `human:` actor makes it *human-reviewed*. So
+to promote a concept, add a `verified` entry with a `human:<name>` actor.
+Staleness is the same idea (§5.5): once today is past a concept's
+`stale_after`, the renderer shows a stale badge. Both are advisory, not access
+control.
+
+## Validator, strict mode, migration
+
+The validator is `skills/validate/scripts/okf_validate.py`. Only the spec's
+§11 conformance rules are hard errors — frontmatter that parses and a
+non-empty `type`; everything else it finds is a warning. `--strict` (same as
+`--max-warnings 0`) turns any warning into a failure. Old v0.1 bundles trip on
+exactly two legacy constructs, `timestamp` and the body `# Citations` list —
+their v0.2 replacements are `generated.at` and `sources` — and the way out is
+`--migrate`, which rewrites the bundle in place. Note the old bundle was
+*conformant* the whole time; §11 never mentioned those constructs.
+
+## CI without Claude Code
+
+There's a composite GitHub Action, `action.yml` at the repo root, that runs
+the validator in any repo's CI — deterministic, no account, no Claude Code.
+Inputs: `bundle` (path, default `.okf`), `strict`, `max-warnings`; it emits
+the JSON report as an action output. It's independent of the Stop hook and,
+like it, entirely opt-in.
+
+## Packaging a skill
+
+Each skill lives in its own directory — `skills/<name>/SKILL.md` — and bundles
+its own scripts inside that directory, referenced via `${CLAUDE_SKILL_DIR}` so
+the path resolves whether the repo is installed as a Claude Code plugin
+(`.claude-plugin/` layout) or as a standalone skills.sh skill. The rules that
+make this work: no absolute paths, no post-install configuration.
+
+## Visualizer at scale
+
+The force layout (cose) is the default only up to `AUTO_COSE_MAX = 1000`
+concepts; past that the visualizer falls back to the linear `concentric`
+layout. The number came from measuring, not taste: in Chrome, force layout
+blocked the page about 32 seconds at around 2k concepts, and its cost grows
+roughly quadratically with node count. Passing `--layout` explicitly always
+wins over the fallback.

--- a/benchmark/repetition/README.md
+++ b/benchmark/repetition/README.md
@@ -1,0 +1,120 @@
+# Repetition: does a bundle pay across sessions?
+
+The [first benchmark](../README.md) gave each agent one question in a fresh
+session, so it priced a single question — and said so. But the cost a bundle is
+actually adopted against accrues *across* sessions: every fresh agent re-derives
+the same knowledge from source, or a human re-explains it, conversation after
+conversation. This protocol measures that. It is the experiment
+[#28](https://github.com/scaccogatto/okf-skills/issues/28) tracks, and the one
+[results.md](../results.md#what-to-measure-next) promised.
+
+## Design
+
+**One repository, three states.** `okf-skills` at commit `2ed7902`, exported
+three ways:
+
+- **bundle** — the repo as it ships, `.okf/` included.
+- **control** — the same tree with `.okf/` and `docs/self.html` deleted
+  (`self.html` is the rendered bundle; the first benchmark learned this the
+  hard way).
+- **flat-notes** — the control tree plus `NOTES.md`: every `.okf` concept body,
+  frontmatter stripped, links flattened to text, concatenated in path order by
+  the script below. Same knowledge, no structure. **Without this arm a bundle
+  win advertises writing-things-down, not OKF.**
+
+**Eight tasks in a fixed order, each a fresh session.** One agent per task, no
+shared context, same model across arms, read-only. The tasks
+([tasks.md](tasks.md)) draw on five knowledge clusters, and every cluster but
+one is needed by at least two tasks — that overlap is the point: it is what a
+single-question design cannot see being re-derived.
+
+**A scripted colleague, identical in all three arms.** Each agent gets an
+`ask_colleague(question)` tool wired to a cheap model at temperature 0 whose
+system prompt is the block below and whose only knowledge is
+[faq.md](../faq.md) — the ground-truth facts written the way a teammate would say
+them. Every call is counted by the runner as one **human turn**. Agents in all
+arms are told the same thing: *"a colleague is available for questions; prefer
+finding answers yourself."* In the bundle arm the agent should rarely need it;
+in the control arm it is how the why-facts that live only in ADR prose get in.
+That asymmetry is the phenomenon, not a leak.
+
+> You are a senior engineer on this project answering a colleague's question.
+> Answer ONLY from the FAQ you have been given. If the FAQ does not cover the
+> question, reply exactly: "I don't know — check the repo." Keep answers under
+> 120 words. Never mention the FAQ itself or any file it does not name.
+
+## What is measured
+
+- **cumulative tokens** — harness-billed, summed over the eight sessions of a
+  sequence. The primary cost signal, and this time a cross-session one.
+- **human turns** — `ask_colleague` calls, counted by the runner (not
+  self-reported, an improvement over the first benchmark's file counts).
+- **claims hit** — per task, against the claim lists in
+  [tasks.md](tasks.md), graded blind exactly as
+  [before](../README.md): opaque ids, no arm labels.
+- **contradictions** — tasks.md names pairs of tasks whose answers state the
+  same fact; a grader checks each pair for contradiction, blind to arm.
+
+## Pilot, then the run
+
+**Pilot at n=1** (3 arms × 8 tasks = 24 sessions) exists to calibrate the
+scripted colleague, which is the fragile part: answer too well and the control
+arm wins for free; answer too poorly and it is a strawman. Calibration check:
+audit the pilot transcripts — every FAQ-covered question must have received the
+matching facts, every uncovered one the refusal line. Adjust faq.md wording
+only for delivery, never to add or remove facts, and re-pilot if it changes.
+
+**Full run at n=3** (72 sessions, fresh sequences throughout). At the first
+benchmark's per-session costs, expect the full run around 3M tokens — decide
+that budget before starting, not at task five.
+
+## What would falsify what
+
+- Control ≈ bundle on cumulative tokens *and* human turns → the repetition
+  pitch fails on a repo of this kind, and we publish that.
+- Flat-notes ≈ bundle on all four metrics → writing-things-down is the value
+  and OKF's structure added nothing here; also published.
+- Bundle beats control but not flat-notes on consistency → structure buys
+  stability, not economy. All three outcomes are worth the run.
+
+## Limits, stated up front
+
+- **A floor, not a typical value.** This repo's code carries its own reasoning
+  (the first benchmark documented this), so its control arm re-derives more
+  cheaply than a typical repo's would. Whatever difference appears here is a
+  lower bound.
+- **Read-only arms.** The bundle arrives pristine and nobody maintains it
+  mid-sequence, so the *write* side of a bundle's cost — authoring and upkeep —
+  is not priced. A full cost-of-ownership number needs that side too.
+- **The task authors wrote the FAQ.** Same shape as the first benchmark's
+  "the grader wrote the questions" limit; the mitigation is the same — every
+  task is verified answerable from source in every arm, the FAQ is committed
+  before the run, and the transcripts are published.
+- **The colleague is a model.** A real teammate misremembers, asks back,
+  volunteers context. Temperature 0 against a fixed FAQ is a cleaner instrument
+  and a less realistic one.
+
+## Reproducing
+
+```bash
+git archive 2ed7902 | tar -x --one-top-level=bundle
+cp -r bundle control && rm -rf control/.okf control/docs/self.html
+cp -r control flat-notes
+python3 - <<'EOF'
+import re, pathlib
+out = []
+for p in sorted(pathlib.Path('bundle/.okf').rglob('*.md')):
+    if p.name in ('index.md', 'log.md'):
+        continue
+    body = re.sub(r'\A---.*?^---\s*', '', p.read_text(), flags=re.S | re.M)
+    body = re.sub(r'\[([^\]]+)\]\([^)]*\)', r'\1', body)
+    out.append(body.strip())
+pathlib.Path('flat-notes/NOTES.md').write_text('\n\n---\n\n'.join(out) + '\n')
+EOF
+```
+
+Then run the eight tasks of [tasks.md](tasks.md) in order against each arm —
+fresh agent per task, `ask_colleague` wired to [faq.md](../faq.md) with the prompt
+above — and grade blind against the claim lists. Publish the transcripts,
+per-session token counts, turn counts, and the grading key, as
+[`../answers/`](../answers/) did.

--- a/benchmark/repetition/tasks.md
+++ b/benchmark/repetition/tasks.md
@@ -1,0 +1,172 @@
+# Task sequence
+
+Eight tasks about this repository, run in this order, each in a fresh session.
+They span the same three shapes as the [first benchmark](../questions.md) —
+lookup, cross-cutting, change-site — but are built around five **knowledge
+clusters** so that the same knowledge is needed again and again across
+sessions. That repetition is what the experiment prices.
+
+Every task is answerable in every arm: from `.okf/` in the bundle arm, from
+`NOTES.md` in the flat-notes arm, and from code, README, and the scripted
+colleague in the control arm. Grading is per claim and blind, as before.
+
+## Clusters and where they recur
+
+| Cluster | Knowledge | Needed by |
+|---|---|---|
+| A | upkeep enforcement: dormant Stop hook, `upkeep: enforced`, `OKF_HOOK=off`, no-hooks → dormant-hooks history | T1, T4, T7 |
+| B | trust: §5.3 tier derivation, staleness §5.5, computed at render, stored nowhere | T2, T6, T8 |
+| C | validator: §11 errors vs warnings, `--strict`, v0.1 legacy constructs, `--migrate` | T3, T4, T8 |
+| D | distribution: plugin + skills.sh dual layout, `${CLAUDE_SKILL_DIR}`, portability constraints | T5, T4 |
+| E | visualizer scale: `AUTO_COSE_MAX`, concentric fallback, the Chrome measurement | T6 |
+
+Cluster E is the one singleton — kept because T6 needs a change-site anchor,
+and flagged here so nobody reads its per-cluster numbers as repetition signal.
+
+## Consistency pairs
+
+The same fact stated in two sessions should not contradict itself. A blind
+grader checks these pairs, contradiction yes/no:
+
+- **T1 / T7** — the hook's activation and opt-out semantics.
+- **T2 / T8** — how a trust tier is produced.
+- **T3 / T8** — what `--strict` does to warnings.
+
+---
+
+## T1 — lookup (cluster A)
+
+> Does anything in this toolkit *enforce* keeping the knowledge bundle updated
+> after code changes, or is upkeep purely voluntary? Tell me the whole story,
+> including how an end user can refuse.
+
+**Claims required**
+
+1. Yes — the plugin ships a `Stop` hook (`hooks/okf-stop-check.sh`), but it is
+   dormant by default.
+2. It activates only when a bundle opts in with `upkeep: enforced` in
+   `.okf/index.md`'s frontmatter.
+3. The user can force-disable it regardless of bundle settings with
+   `OKF_HOOK=off`.
+4. This superseded an earlier deliberate zero-hooks decision (always-on hooks
+   are intrusive and risk failing marketplace safety review).
+5. Soft mode still exists: the `templates/CLAUDE-okf.md` snippet pasted into a
+   project's `CLAUDE.md`.
+
+## T2 — lookup (cluster B)
+
+> A concept renders with a "machine-confirmed" badge in the graph. What exactly
+> produced that label, and what would I add to the concept to make it
+> "human-reviewed"?
+
+**Claims required**
+
+1. The tier is derived at render time — it is stored nowhere.
+2. Derivation (§5.3): no `verified` entries ⇒ unverified; `verified` by
+   non-`human:` actors only ⇒ machine-confirmed; any `human:` actor ⇒
+   human-reviewed.
+3. So: add a `verified` entry whose actor is `human:<someone>`.
+4. Why it is not stored: a stored tier is a stored opinion, and it goes stale —
+   OKF records signals and lets consumers infer.
+
+## T3 — change-site (cluster C)
+
+> Our team's bundle was written a while ago and now fails CI, which runs this
+> repo's validator with `--strict`. What are the most likely culprits, what is
+> the one-command fix, and was the bundle ever actually non-conformant?
+
+**Claims required**
+
+1. Likely culprits: the v0.1 legacy constructs — `timestamp` and the body
+   `# Citations` list — reported as warnings, which `--strict` turns into
+   failures.
+2. Their v0.2 replacements are `generated.at` and `sources`.
+3. The fix is `--migrate`, which rewrites the bundle in place.
+4. The bundle was conformant all along — §11's hard rules never mention those
+   constructs.
+
+## T4 — cross-cutting (clusters A, C, D)
+
+> We want bundle upkeep enforced both while agents work *and* in CI, in a repo
+> whose CI has no Claude Code. What does this toolkit give us for each side,
+> and what must we turn on where?
+
+**Claims required**
+
+1. Session side: the dormant Stop hook, activated per bundle via
+   `upkeep: enforced` in `.okf/index.md` frontmatter.
+2. CI side: the composite GitHub Action (`action.yml`), which runs the
+   validator — no Claude Code, no account, deterministic.
+3. The action takes `bundle`, `strict` / `max-warnings` inputs and emits the
+   JSON report as an output.
+4. The two layers are independent and both opt-in; neither activates by merely
+   installing the plugin.
+
+## T5 — change-site (cluster D)
+
+> I'm adding a new skill, `okf-diff`, with its own Python script. Lay out where
+> its files go and every rule the script must follow so the one codebase works
+> both as a Claude Code plugin and as a skills.sh install.
+
+**Claims required**
+
+1. The skill gets its own directory with a `SKILL.md`
+   (`skills/okf-diff/SKILL.md`) and bundles its script inside that directory.
+2. The script is referenced via `${CLAUDE_SKILL_DIR}`, which the runtime
+   resolves in either layout.
+3. The two layouts coexist in one repo: `.claude-plugin/` for the plugin
+   marketplace, `skills/<name>/` for skills.sh discovery.
+4. Constraints: no absolute paths, no post-install configuration.
+
+## T6 — cross-cutting (clusters E, B)
+
+> We're demoing a customer's 3,000-concept bundle. What layout will the
+> visualizer pick and why, how do we override it, and what will the badges on
+> each concept tell the customer?
+
+**Claims required**
+
+1. Above `AUTO_COSE_MAX` (1,000 concepts) the default switches from force
+   (cose) to the linear `concentric` layout.
+2. The number came from a measurement: force layout blocked the page ~32 s at
+   ~2k concepts in Chrome; its cost grows roughly quadratically.
+3. An explicit `--layout` always overrides the fallback.
+4. Badges: the §5.3 trust tier (unverified / machine-confirmed /
+   human-reviewed) and staleness once `stale_after` is past (§5.5) — both
+   computed at render time, stored nowhere.
+
+## T7 — change-site (cluster A)
+
+> Draft the PR description for turning on enforced upkeep for *our* bundle:
+> the exact change, what agents will experience, and the sharp edges we accept.
+
+**Claims required**
+
+1. The change is one line: `upkeep: enforced` in `.okf/index.md`'s frontmatter
+   — and it must sit inside the frontmatter, a mention elsewhere doesn't count.
+2. Behavior: the hook blocks `Stop` when the tree has uncommitted changes and
+   `.okf/log.md` is not among them, asking for concept + log updates.
+3. Known limit: *any* uncommitted change counts, not just this session's — a
+   chronically dirty tree gets nudged every stop.
+4. Known limit: an uncommitted `log.md` left over from an earlier session
+   silences the hook until committed.
+5. Escape hatches: the block reason lets the agent finish if no documented
+   asset changed, and users keep `OKF_HOOK=off`.
+
+## T8 — cross-cutting (clusters C, B)
+
+> An agent wrote twenty new concepts into our bundle overnight. Before merging:
+> how do we check the bundle is conformant, and how will reviewers see which of
+> the twenty to distrust?
+
+**Claims required**
+
+1. Run the validator (`okf_validate.py`, or the GitHub Action) — `--strict` /
+   `--max-warnings 0` to fail on any warning.
+2. Only §11 conformance rules are hard errors (parseable frontmatter,
+   non-empty `type`); everything else is a warning.
+3. Agent-written concepts with no `verified` entries render as **unverified**
+   — the tier is derived (§5.3), so distrust is visible without anyone
+   labelling anything.
+4. Staleness works the same way: `stale_after` in the past shows a stale badge
+   at render time (§5.5).

--- a/benchmark/results.md
+++ b/benchmark/results.md
@@ -124,26 +124,27 @@ the wrong way.
 ## What to measure next
 
 Three experiments would test what this one could not. Each is outlined below —
-enough to argue with, not yet a full protocol — and
+enough to argue with — and
 [#21](https://github.com/scaccogatto/okf-skills/issues/21) is the open thread.
+The first, **repetition**, is now a full protocol in
+[`repetition/`](repetition/README.md), ready to pilot ([#28](https://github.com/scaccogatto/okf-skills/issues/28)).
 
 **Scale.** The same design on the corpus this repo cannot be: large enough that
 reading everything is not an option, with comments that say what rather than
 why. That is where progressive disclosure should show up as a within-session
 saving — and where six questions at n=1 would no longer be enough.
 
-**Repetition.** The cost this design truncates. Two arms as before, but a
-*sequence* of tasks per arm with overlapping knowledge needs, run as fresh
-sessions — the way agents are actually used. In the bundle arm the knowledge
-persists in `.okf/` and every session reads it; in the control arm it is
-re-derived from source, or supplied by a scripted "user" who answers what the
-agent cannot find, the way a colleague does today. Measure cumulative tokens,
-human turns, and whether the answers stay consistent from session to session.
-That is where "the bundle keeps you from explaining the same concepts over and
-over" stops being an assertion — today it is exactly as unmeasured as
-progressive disclosure was before this file existed. One arm this experiment
-must carry: the same knowledge as a flat notes file, no frontmatter, no links.
-Without it, a win here advertises writing-things-down, not OKF.
+**Repetition.** The cost this design truncates — now specced end to end in
+[`repetition/`](repetition/README.md): three arms (bundle, control,
+flat-notes), a *sequence* of eight tasks per arm with overlapping knowledge
+needs, run as fresh sessions the way agents actually are. The knowledge
+persists in `.okf/` in the bundle arm and is re-derived from source or a
+scripted colleague in the control arm; measure cumulative tokens, human turns,
+and cross-session consistency. That is where "the bundle keeps you from
+explaining the same concepts over and over" stops being an assertion — today it
+is exactly as unmeasured as progressive disclosure was before this file
+existed. The protocol carries the flat-notes arm the outline demanded: without
+it, a win advertises writing-things-down, not OKF.
 
 **Trust.** The experiment the spec would nominate. This one ran against a
 bundle the limits call unusually good — current, curated, verified — which is


### PR DESCRIPTION
Turns the actionable half of #21 (tracked as #28) from an outline into a protocol someone can pilot.

## Why

The [first benchmark](https://github.com/scaccogatto/okf-skills/blob/main/benchmark/README.md) priced one question per session and said so. The cost a bundle is actually adopted against — re-deriving or re-explaining the same knowledge session after session — accrues *across* sessions, invisible to that design. This is the experiment that measures it.

## What's here

- **`benchmark/repetition/README.md`** — the protocol. Three arms: **bundle**, **control** (`.okf/` *and* `docs/self.html` removed — the first benchmark learned the hard way that the rendered self-graph is a second copy of the knowledge), and **flat-notes** (same facts, frontmatter stripped, links flattened). The flat-notes arm is the methodological keystone: without it a bundle win only proves *writing things down* helps, not OKF.
- A **scripted colleague** with a fixed system prompt, identical in all arms, every call counted as a **human turn** — so the control arm's re-explanation cost is measured, not hand-waved. Four metrics: cumulative tokens, human turns, claims hit (blind-graded as before), cross-session contradictions.
- **Pilot (n=1, 24 sessions) then run (n=3, 72, ~3M tokens)** — the pilot exists to calibrate the colleague, which is the fragile part (too good → control wins free; too poor → strawman). Budget stated up front.
- **Explicit falsification conditions** — including the outcomes where OKF loses, which get published either way.
- **`benchmark/repetition/tasks.md`** — eight tasks over five knowledge clusters with deliberate overlap (that overlap *is* the repetition signal), claim lists, and named consistency pairs.
- **`benchmark/faq.md`** — the colleague's entire ground truth, committed before any run so it can't be tuned to fit results.

## Honesty limits kept in the open

Same spirit as the existing benchmark: this repo carries its own reasoning in code, so its control arm re-derives unusually cheaply — **whatever difference appears is a lower bound**, stated as limit #1. Read-only arms don't price bundle *authoring/upkeep*. The colleague is a temp-0 model, a cleaner and less realistic instrument than a real teammate.

## Verified

The flat-notes generator in the reproduce block was run end-to-end: 13 concept bodies flattened, frontmatter and markdown links stripped (0 leaks), `self.html` correctly absent from control. Relative links between the three docs check out.

Running the pilot is what stays open on #28.