### PR TITLE
docs: correct the README Stop-hook section (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,15 +168,18 @@ tasks and write knowledge back after changes, paste
 `CLAUDE.md` (or `~/.claude/CLAUDE.md` for all projects).
 
 **Enforced upkeep (opt-in).** The plugin also ships a `Stop` hook,
-`hooks/okf-stop-check.sh`, but it is *dormant by default* — a single file read
-and an exit on every session, for every repo that doesn't ask for it. Activate
-it for a bundle by adding `upkeep: enforced` to `.okf/index.md`'s frontmatter;
-once set, the hook blocks `Stop` when there are uncommitted changes but
-`.okf/log.md` was not touched, nudging the agent to update the matching
-concept and log the change before finishing. Force-disable it regardless of
-what any bundle declares by setting `OKF_HOOK=off` in your environment. See
-the [dormant hooks decision](.okf/decisions/dormant-hooks.md) for why it
-replaced the earlier zero-hooks stance.
+`hooks/okf-stop-check.sh`, *dormant by default* — a single file read and an exit
+on every session, for every repo that doesn't ask for it. Activate it for a
+bundle by adding `upkeep: enforced` to `.okf/index.md`'s frontmatter (it must
+sit **inside** the frontmatter — a mention elsewhere in the file doesn't count).
+Once set, the hook blocks `Stop` when there are **modified tracked files** but
+`.okf/log.md` isn't among them, nudging the agent to update the matching concept
+and log the change before finishing; if nothing documented changed, it may
+finish. Untracked files (build dirs, `.claude/`) are ignored on purpose. A user
+force-disables it regardless of what any bundle declares by setting
+`OKF_HOOK=off` in their environment. Full gate sequence and known limits live in
+the [stop-hook concept](.okf/components/stop-hook.md); the rationale is in the
+[dormant hooks decision](.okf/decisions/dormant-hooks.md).
 
 ## How a bundle looks
 


### PR DESCRIPTION
Closes #31 (document the Stop hook → "just update the readme").

The section existed since #27 but went stale at #29: it said the hook fires on *uncommitted changes*, when since #29 it counts only **modified tracked files** (untracked paths ignored). Fixed, and while there:

- notes the `upkeep: enforced` flag must sit **inside** the frontmatter (a mention elsewhere doesn't arm it);
- notes the agent may finish if nothing documented changed;
- says untracked files (build dirs, `.claude/`) are ignored on purpose;
- links to the [stop-hook concept](.okf/components/stop-hook.md) for the full 6-gate sequence + known limits instead of duplicating them in the README.

Verified line-by-line against `hooks/okf-stop-check.sh`.

**Out-of-scope nit spotted, not fixed here:** the hook's *block message* (`okf-stop-check.sh:22`) still reads "there are uncommitted changes" — same post-#29 imprecision, but it's the script's user-facing string, not the README. Worth a one-word fix in a separate PR if wanted.