### PR TITLE
visualize: surface producer-defined frontmatter, render footnotes, run offline

### DIFF
--- a/skills/visualize/scripts/okf_visualize.py
+++ b/skills/visualize/scripts/okf_visualize.py
@@ -427,21 +427,36 @@ HTML = r"""<!doctype html><html lang="en"><head><meta charset="utf-8">
 __OGIMAGE__
 __LIBS__
 <style>
- :root{--bg:#0e0f13;--panel:#16181f;--line:#262a35;--fg:#e6e8ee;--mut:#9aa3b2;--accent:#8ab4ff}
+ :root{--bg:#0e0f13;--panel:#16181f;--line:#262a35;--fg:#e6e8ee;--mut:#9aa3b2;--accent:#8ab4ff;
+   /* One declaration for the panel's width: the grid column and the control bar
+      both derive from it, so the bar cannot drift over the panel as controls
+      are added. */
+   --side:clamp(400px,34vw,560px);
+   /* Width the title block reserves at the top-left. */
+   --hdr:250px}
  *{box-sizing:border-box} html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);
    font:14px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
  /* The row must be stated. Left implicit it sizes to `auto`, i.e. to the tallest
     item — a long concept body then stretched #side past the viewport and the page
     grew its own scrollbar on top of the panel's, which in turn forced a spurious
     horizontal one. Pinning the row to 100% keeps the panel scrolling inside. */
- #app{display:grid;grid-template-columns:1fr clamp(400px,34vw,560px);grid-template-rows:100%;height:100vh}
+ #app{display:grid;grid-template-columns:1fr var(--side);grid-template-rows:100%;height:100vh}
  #cy{width:100%;height:100%}
  #side{border-left:1px solid var(--line);background:var(--panel);overflow:auto;padding:18px}
  header{position:absolute;top:0;left:0;padding:14px 18px;z-index:5;pointer-events:none}
  h1{font-size:15px;margin:0;font-weight:650} .sub{color:var(--mut);font-size:12px;margin-top:2px}
- #bar{position:absolute;top:12px;left:50%;transform:translateX(-50%);z-index:5;display:flex;gap:8px}
+ /* Centred in the gap between the title and the panel — the two fixed things it
+    would otherwise sit on top of. Viewport-centred, it slid under the panel as
+    soon as it grew by one control; measured from the left edge alone, it landed
+    on the title instead. */
+ #bar{position:absolute;top:12px;left:var(--hdr);right:var(--side);z-index:5;display:flex;gap:8px;
+   justify-content:center;flex-wrap:wrap;padding:0 12px}
  #bar input,#bar select{background:var(--panel);border:1px solid var(--line);color:var(--fg);
    border-radius:8px;padding:8px 10px;outline:none;font-size:13px}
+ #derivedbox{display:flex;align-items:center;gap:6px;background:var(--panel);
+   border:1px solid var(--line);border-radius:8px;padding:8px 10px;font-size:13px;
+   color:var(--mut);cursor:pointer;user-select:none;white-space:nowrap}
+ #derivedbox input{margin:0;cursor:pointer;accent-color:var(--accent)}
  #search{width:min(300px,32vw)}
  #legend{position:absolute;bottom:14px;left:18px;z-index:5;display:flex;flex-wrap:wrap;gap:6px;max-width:60vw}
  .chip{display:flex;align-items:center;gap:6px;background:var(--panel);border:1px solid var(--line);

--- a/skills/visualize/scripts/okf_visualize.py
+++ b/skills/visualize/scripts/okf_visualize.py
@@ -5,13 +5,22 @@
 # ///
 """Render an Open Knowledge Format (OKF) bundle as a single self-contained,
 interactive HTML graph (`viz.html`). No backend, no install on the viewing side,
-no data leaves the page — concepts become nodes (coloured by `type`, sized by
-body length), markdown links and bundle-internal `sources` become edges, and
-clicking a node opens a wiki-style panel with its rendered markdown, OKF v0.2
-provenance/trust/lifecycle metadata, outgoing links, and "Cited by" backlinks.
+no data leaves the page — concepts become nodes (coloured by `type` or by any
+producer-defined frontmatter field, sized by body length), markdown links and
+bundle-internal `sources` become edges, and clicking a node opens a wiki-style
+panel with its rendered markdown, OKF v0.2 provenance/trust/lifecycle metadata,
+outgoing links, and "Cited by" backlinks.
 
 Features: force/concentric/breadth-first/circle/grid layouts, per-type filter,
 free-text search, neighbour highlight, clickable cross-links and backlinks.
+
+Producer-defined frontmatter (§4.1) reaches the page, so a bundle can be coloured
+and grouped by its own dimensions — owning team, tier, environment — and searched
+by its own identifiers. `--derive-edge` turns a field that names another concept
+into an edge, drawn dashed to keep an inference distinct from a written link.
+`--vendor` inlines the runtime libraries so the file owes nothing to a network,
+and `--report` prints bundle health: orphans, broken links, undefined footnote
+references, stale concepts and drafts.
 
 The default layout is force (cose) up to AUTO_COSE_MAX concepts, then the linear
 concentric layout — force-directed cost grows roughly quadratically with node
@@ -22,6 +31,7 @@ Run:  uv run okf_visualize.py <bundle-dir> [-o viz.html]
 from __future__ import annotations
 
 import argparse
+import datetime as _dt
 import json
 import re
 import sys
@@ -38,6 +48,11 @@ AUTO_COSE_MAX = 1000
 # Above this the page is slow on any layout (23k concepts measured: ~27 s load,
 # ~650 MB heap) and reads as a hairball — warn and suggest rendering a subtree.
 SCALE_WARN = 5000
+# Bodies were capped at 8 000 characters, which silently dropped the tail of the
+# longest concepts — and footnote definitions sit at the bottom, so exactly the
+# documents that cite most lost every citation. Raised to a ceiling no real
+# concept reaches; a bundle that does can lower it, and any cut now says so.
+BODY_MAX = 200_000
 FENCE = re.compile(r"^(```|~~~)")
 LINK = re.compile(r"(?<!\!)\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
 
@@ -97,6 +112,38 @@ def resolve(target: str, path: Path, bundle: Path):
         if cand.is_relative_to(bundle.resolve()) else None
 
 
+FN_DEF = re.compile(r"^\[\^([^\]]+)\]:", re.M)
+FN_REF = re.compile(r"\[\^([^\]]+)\](?!:)")
+
+
+def undefined_footnotes(body: str):
+    """Footnote references the document never defines.
+
+    A bundle carries most of its provenance in footnotes, and a reference with no
+    definition renders as bare `[^cluster]` in the middle of a sentence — a
+    citation that silently isn't one. Frontmatter validators never see it,
+    because it lives in the body.
+    """
+    defined = set(FN_DEF.findall(body))
+    return sorted({ref for ref in FN_REF.findall(body) if ref not in defined})
+
+
+def is_dangling(target: str, path: Path, bundle: Path) -> bool:
+    """Whether an in-body link names a bundle file that is not there.
+
+    Answered against the filesystem, not against the node list, because the two
+    disagree in ways that would otherwise be reported as defects: `index.md` is
+    a real file that is deliberately not a concept, and an external
+    `https://…/notes.md` merely ends in `.md` while naming nothing local. Both
+    resolve to a plausible-looking id, and neither is broken.
+    """
+    t = str(target).split("#", 1)[0]
+    if "://" in t or not t.endswith(".md"):
+        return False
+    fs = (bundle / t.lstrip("/")) if t.startswith("/") else (path.parent / t)
+    return not fs.exists()
+
+
 def read_sources(meta: dict, path: Path, bundle: Path):
     """§5.1 `sources`, flattened for display. `cid` is set when the source is
     itself a concept in this bundle — that derivation is a real graph edge."""
@@ -141,8 +188,179 @@ def read_trust(meta: dict):
     return generated, verified
 
 
-def build(bundle: Path):
+# §4.1 reserves this top-level vocabulary. Everything else a document carries is
+# an "other producer-defined key/value pair" — an extension namespace such as
+# `acme:` or `wiki:`, which the spec tells consumers to preserve rather than
+# reject. Those keys are the only place a bundle records its own dimensions
+# (owning team, tier, environment), so a graph that drops them can only ever
+# colour by `type`.
+OKF_KEYS = frozenset({
+    "type", "title", "description", "resource", "tags", "generated", "verified",
+    "status", "stale_after", "sources", "usage_window", "runtime", "parameters",
+    "computation", "executor", "attester",
+})
+
+
+def read_extensions(meta: dict):
+    """Producer-defined frontmatter (§4.1), flattened to dotted scalar paths.
+
+    A nested namespace (`acme: {owner_team: infra}`) becomes `acme.owner_team`, so
+    every extension arrives as one flat attribute the viewer can group on
+    without knowing any producer's schema in advance.
+
+    Only scalars survive. A list or a deeper structure has no single value to
+    colour a node by, and silently picking its first element would invent a fact
+    the document never stated.
+    """
+    out = {}
+
+    def walk(prefix: str, value):
+        if isinstance(value, dict):
+            for k, v in value.items():
+                walk(f"{prefix}.{k}" if prefix else str(k), v)
+        elif isinstance(value, bool):
+            # YAML round-trips these as `true`/`false`; Python's repr would put
+            # `True` in front of a reader who never wrote that.
+            out[prefix] = "true" if value else "false"
+        elif isinstance(value, (str, int, float)):
+            out[prefix] = str(value)
+
+    for key, value in meta.items():
+        if key not in OKF_KEYS:
+            walk(str(key), value)
+    return out
+
+
+LIBS = (
+    ("cytoscape", "https://cdn.jsdelivr.net/npm/cytoscape@3.30.2/dist/cytoscape.min.js"),
+    ("marked", "https://cdn.jsdelivr.net/npm/marked@14/marked.min.js"),
+    ("dompurify", "https://cdn.jsdelivr.net/npm/dompurify@3.4.12/dist/purify.min.js"),
+)
+CDN_TAGS = (
+    '<script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.2/dist/cytoscape.min.js"></script>\n'
+    '<script src="https://cdn.jsdelivr.net/npm/marked@14/marked.min.js"></script>\n'
+    '<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.12/dist/purify.min.js"'
+    ' integrity="sha384-piCcpDdJ7qVeK4Tv8Z6Hpcr3ZBIgP16TxQTPVfsLFdZ5uDgwc3Y8Ho7oUnqf12qu"'
+    ' crossorigin="anonymous"></script>'
+)
+
+
+def vendor_libs(cache_dir: Path) -> str:
+    """Inline the three runtime libraries so the page owes nothing to a network.
+
+    The default build calls itself self-contained while fetching three scripts
+    from a CDN at open time. That page dies behind an air gap, dies under a
+    content-security policy, and dies the day a version is unpublished. Inlining
+    costs about 700 KB once and makes the file mean what it says.
+    """
+    import urllib.request
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    out = []
+    for name, url in LIBS:
+        cached = cache_dir / f"{name}.js"
+        if not cached.exists():
+            print(f"fetching {name} …", file=sys.stderr)
+            try:
+                with urllib.request.urlopen(url, timeout=60) as resp:
+                    cached.write_bytes(resp.read())
+            except Exception as exc:  # noqa: BLE001 — surfaced, never swallowed
+                sys.exit(f"error: --vendor could not fetch {name} from {url}: {exc}\n"
+                         f"       place the file at {cached} manually and re-run.")
+        source = cached.read_text(encoding="utf-8")
+        # The tokenizer, not the JS parser, decides where a script ends: a bare
+        # </script> inside a minified bundle would close this one early.
+        out.append("<script>" + source.replace("</script>", "<\\/script>") + "</script>")
+    return "\n".join(out)
+
+
+def print_report(nodes, edges, audit) -> None:
+    """Bundle health, on stderr so it never lands in a redirected HTML file."""
+    written = [e for e in edges if e.get("origin") != "derived"]
+    degree = {n["id"]: 0 for n in nodes}
+    for edge in written:
+        degree[edge["source"]] += 1
+        degree[edge["target"]] += 1
+    orphans = sorted(nid for nid, deg in degree.items() if deg == 0)
+    today = _dt.date.today().isoformat()
+    stale = sorted(n["id"] for n in nodes if n["stale_after"] and n["stale_after"] < today)
+    draft = sorted(n["id"] for n in nodes if n["status"] == "draft")
+
+    def block(title, items, note=""):
+        print(f"\n{title}: {len(items)}{note}", file=sys.stderr)
+        for item in items:
+            print(f"  {item}", file=sys.stderr)
+
+    print(f"\n— bundle report —\nconcepts: {len(nodes)}  "
+          f"written edges: {len(written)}  derived: {audit['derived']}  "
+          f"identifier field: {audit['identifier'] or '(none detected)'}", file=sys.stderr)
+    block("orphans (no written link in or out)", orphans)
+    block("broken links", [f"{d['source']} → {d['target']}" for d in audit["dangling"]],
+          "  (§6.1 tolerates these; they may be knowledge not yet written)")
+    block("undefined footnote references",
+          [f"{n['source']} → [^{n['ref']}]" for n in audit["loose_notes"]])
+    block("past stale_after", stale)
+    block("status: draft", draft)
+
+
+def find_identifier_key(nodes):
+    """The extension key that behaves like an identifier.
+
+    A key qualifies when every concept carries it and no two concepts share a
+    value — the definition of an identifier, discovered rather than configured,
+    so no producer's spelling (`acme.id`, `wiki.uid`) is baked in here.
+    """
+    seen = {}
+    for node in nodes:
+        for key, value in node["ext"].items():
+            seen.setdefault(key, []).append(value)
+    best = None
+    for key, values in seen.items():
+        if len(values) == len(nodes) and len(set(values)) == len(nodes):
+            if best is None or len(key) < len(best):
+                best = key
+    return best
+
+
+def derive_edges(nodes, derivations):
+    """Edges implied by frontmatter that already exists.
+
+    Two sources, both refusing to invent vocabulary:
+
+    * **Exact match** — an extension value equal to some concept's identifier is
+      a reference to it. `superseded_by: an-rabbitmq-adoption` names a concept,
+      so the graph should show that it does.
+    * **Declared joins** — `--derive-edge acme.owner_team=team-{}` for the case
+      where a value keys a concept without equalling its id. This stays an
+      explicit argument because the transform is a property of one bundle's
+      conventions, and guessing it would put edges on the page that no document
+      asserts.
+    """
+    ident = find_identifier_key(nodes)
+    if not ident:
+        return [], None
+    by_ident = {n["ext"][ident]: n["id"] for n in nodes}
+    out, seen = [], set()
+    for node in nodes:
+        for key, value in node["ext"].items():
+            if key == ident:
+                continue
+            candidates = [value] if value in by_ident else []
+            for dkey, pattern in derivations:
+                if dkey == key:
+                    candidates.append(pattern.replace("{}", value))
+            for cand in candidates:
+                target = by_ident.get(cand)
+                if target and target != node["id"] and (node["id"], target, key) not in seen:
+                    seen.add((node["id"], target, key))
+                    out.append({"source": node["id"], "target": target,
+                                "origin": "derived", "label": key})
+    return out, ident
+
+
+def build(bundle: Path, derivations=(), body_max: int = BODY_MAX):
     nodes, edges, seen = [], [], set()
+    dangling, loose_notes = [], []
     files = sorted(p for p in bundle.rglob("*.md") if p.is_file() and p.name not in RESERVED)
     ids = {p.relative_to(bundle).with_suffix("").as_posix() for p in files}
     for p in files:
@@ -157,6 +375,10 @@ def build(bundle: Path):
         body = body.strip()
         generated, verified = read_trust(meta)
         sources = read_sources(meta, p, bundle)
+        # Checked against the whole document: definitions live at the bottom, so
+        # asking the truncated copy would invent undefined references.
+        for ref in undefined_footnotes(body):
+            loose_notes.append({"source": cid, "ref": ref})
         nodes.append({
             "id": cid,
             "type": str(meta.get("type", "Untyped")),
@@ -164,21 +386,35 @@ def build(bundle: Path):
             "description": str(meta.get("description", "")),
             "tags": meta.get("tags", []) if isinstance(meta.get("tags"), list) else [],
             "group": cid.split("/")[0] if "/" in cid else "(root)",
+            "ext": read_extensions(meta),
             "sz": max(24, min(70, 24 + len(body) // 200)),
             "status": str(meta.get("status", "")),
             "stale_after": str(meta.get("stale_after") or ""),
             "generated": generated,
             "verified": verified,
             "sources": sources,
-            "body": body[:8000],
+            "body": (body if len(body) <= body_max else
+                     body[:body_max] + f"\n\n*— truncated at {body_max:,} characters —*"),
         })
         targets = link_targets(body) + [s["resource"] for s in sources if s["cid"]]
         for t in targets:
             tgt = resolve(t, p, bundle)
+            if is_dangling(t, p, bundle):
+                # §6.1 calls this tolerable, not invisible: a link to a concept
+                # that does not exist may be knowledge not yet written, but the
+                # author is the one who should get to decide which it is.
+                dangling.append({"source": cid, "target": t})
+                continue
             if tgt and tgt in ids and tgt != cid and (cid, tgt) not in seen:
                 seen.add((cid, tgt))
-                edges.append({"source": cid, "target": tgt})
-    return nodes, edges
+                edges.append({"source": cid, "target": tgt, "origin": "link"})
+    derived, ident = derive_edges(nodes, derivations)
+    # A derived edge that merely restates a written link adds no information and
+    # would double the line weight between the same two concepts.
+    written = {(e["source"], e["target"]) for e in edges}
+    derived = [e for e in derived if (e["source"], e["target"]) not in written]
+    return nodes, edges + derived, {"dangling": dangling, "identifier": ident,
+                                    "derived": len(derived), "loose_notes": loose_notes}
 
 
 HTML = r"""<!doctype html><html lang="en"><head><meta charset="utf-8">
@@ -189,9 +425,7 @@ HTML = r"""<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta property="og:type" content="website">
 <meta name="twitter:card" content="summary_large_image">
 __OGIMAGE__
-<script src="https://cdn.jsdelivr.net/npm/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/marked@14/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.12/dist/purify.min.js" integrity="sha384-piCcpDdJ7qVeK4Tv8Z6Hpcr3ZBIgP16TxQTPVfsLFdZ5uDgwc3Y8Ho7oUnqf12qu" crossorigin="anonymous"></script>
+__LIBS__
 <style>
  :root{--bg:#0e0f13;--panel:#16181f;--line:#262a35;--fg:#e6e8ee;--mut:#9aa3b2;--accent:#8ab4ff}
  *{box-sizing:border-box} html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);
@@ -200,7 +434,7 @@ __OGIMAGE__
     item — a long concept body then stretched #side past the viewport and the page
     grew its own scrollbar on top of the panel's, which in turn forced a spurious
     horizontal one. Pinning the row to 100% keeps the panel scrolling inside. */
- #app{display:grid;grid-template-columns:1fr 400px;grid-template-rows:100%;height:100vh}
+ #app{display:grid;grid-template-columns:1fr clamp(400px,34vw,560px);grid-template-rows:100%;height:100vh}
  #cy{width:100%;height:100%}
  #side{border-left:1px solid var(--line);background:var(--panel);overflow:auto;padding:18px}
  header{position:absolute;top:0;left:0;padding:14px 18px;z-index:5;pointer-events:none}
@@ -229,8 +463,41 @@ __OGIMAGE__
  .rel{margin:10px 0} .rel h4{margin:0 0 4px;font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--mut)}
  .rel a{display:block;color:var(--accent);cursor:pointer;font-size:13px;padding:1px 0;text-decoration:none}
  .rel a:hover{text-decoration:underline}
- .body{border-top:1px solid var(--line);padding-top:12px;margin-top:12px} .body table{border-collapse:collapse;display:block;overflow:auto}
- .body td,.body th{border:1px solid var(--line);padding:4px 8px} .body code{background:#1d2230;padding:1px 5px;border-radius:4px}
+ /* The body is the half of this panel people actually read. It gets prose
+    treatment: a looser measure, a real heading scale, and tables and code that
+    are contained rather than left to burst the panel's width. */
+ .body{border-top:1px solid var(--line);padding-top:16px;margin-top:16px;
+   font-size:14.5px;line-height:1.68;overflow-wrap:break-word}
+ .body>*:first-child{margin-top:0}
+ .body h1,.body h2,.body h3,.body h4{line-height:1.3;font-weight:650;margin:1.6em 0 .5em;color:#f2f4f8}
+ .body h1{font-size:1.32em} .body h2{font-size:1.18em}
+ .body h3{font-size:1.05em} .body h4{font-size:.95em;color:var(--mut)}
+ .body h1,.body h2{border-bottom:1px solid var(--line);padding-bottom:.28em}
+ .body p{margin:.85em 0}
+ .body ul,.body ol{margin:.75em 0;padding-left:1.35em} .body li{margin:.3em 0}
+ .body li>ul,.body li>ol{margin:.3em 0}
+ .body a{color:var(--accent);text-decoration:none;border-bottom:1px solid #33415c}
+ .body a:hover{border-bottom-color:var(--accent)}
+ .body blockquote{margin:1em 0;padding:.1em 0 .1em 1em;border-left:3px solid #2f3a4d;color:var(--mut)}
+ .body hr{border:0;border-top:1px solid var(--line);margin:1.8em 0}
+ .body strong{color:#f2f4f8;font-weight:650}
+ /* A wide table must scroll inside its own box; letting it size the panel is
+    what pushed a second scrollbar onto the page. */
+ .body .tw{overflow-x:auto;margin:1em 0;border:1px solid var(--line);border-radius:8px}
+ .body table{border-collapse:collapse;width:100%;font-size:13px}
+ .body th{background:#1b1f29;color:#f2f4f8;font-weight:650;text-align:left;white-space:nowrap}
+ .body td,.body th{border-bottom:1px solid var(--line);border-right:1px solid var(--line);padding:6px 10px;vertical-align:top}
+ .body tr:last-child td{border-bottom:0} .body td:last-child,.body th:last-child{border-right:0}
+ .body code{background:#1d2230;border:1px solid #242b3a;padding:.1em .4em;border-radius:4px;
+   font:12.5px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+ .body pre{background:#12151d;border:1px solid var(--line);border-radius:8px;padding:12px 14px;
+   overflow-x:auto;margin:1em 0} .body pre code{background:none;border:0;padding:0;font-size:12.5px}
+ /* Footnotes are the quiet apparatus under the argument, not part of it. */
+ .body sup a{border:0;font-size:.78em;padding:0 .12em}
+ .body .footnotes{margin-top:2em;padding-top:.8em;border-top:1px solid var(--line);
+   font-size:13px;color:var(--mut)}
+ .body .footnotes ol{padding-left:1.2em} .body .footnotes li{margin:.35em 0}
+ .body .footnotes p{margin:.2em 0}
  .body pre{background:#1d2230;padding:10px;border-radius:8px;overflow:auto} .body img{max-width:100%}
  .empty{color:var(--mut)} a{color:var(--accent)}
  .src{pointer-events:auto;color:var(--accent);margin-left:10px;text-decoration:none} .src:hover{text-decoration:underline}
@@ -240,6 +507,8 @@ __OGIMAGE__
 <div id="bar">
  <input id="search" placeholder="search concepts…">
  <select id="type"><option value="">all types</option></select>
+ <select id="colorby" title="colour and group nodes by a frontmatter field"></select>
+ <label id="derivedbox" title="edges inferred from frontmatter rather than written as links"><input type="checkbox" id="showderived"> derived</label>
  <select id="layout">
   <option value="cose">force</option><option value="concentric">concentric</option>
   <option value="breadthfirst">breadth-first</option><option value="circle">circle</option><option value="grid">grid</option>
@@ -254,10 +523,27 @@ const outL={}, inL={};
 NODES.forEach(n=>{outL[n.id]=[];inL[n.id]=[];});
 EDGES.forEach(e=>{outL[e.source].push(e.target);inL[e.target].push(e.source);});
 const types=[...new Set(NODES.map(n=>n.type))].sort();
-const color=Object.fromEntries(types.map((t,i)=>[t,PALETTE[i%PALETTE.length]]));
+// A field earns a place in the colour-by list only if it actually partitions the
+// bundle. One distinct value paints every node identically; a value per node (an
+// id, a URL, a health path) is N colours and no signal. The band between is where
+// the real axes live — owning team, tier, environment, family.
+const DIM_MIN=2, DIM_MAX=24;
+const extVals={};
+NODES.forEach(n=>{const e=n.ext||{};for(const k in e){(extVals[k]=extVals[k]||new Set()).add(e[k]);}});
+const dims=['type',...Object.keys(extVals)
+ .filter(k=>extVals[k].size>=DIM_MIN&&extVals[k].size<=DIM_MAX).sort()];
+// Nodes missing the current field are not dropped — they group under one explicit
+// bucket, so an incomplete field reads as a visible gap instead of a silent one.
+const UNSET='(unset)';
+let dim='type';
+const dimValue=(n,d)=>d==='type'?n.type:(((n.ext||{})[d])||UNSET);
+let buckets=[],color={};
+function recolour(){buckets=[...new Set(NODES.map(n=>dimValue(n,dim)))].sort();
+ color=Object.fromEntries(buckets.map((b,i)=>[b,PALETTE[i%PALETTE.length]]));}
+recolour();
 const off=new Set();
 const cy=cytoscape({container:document.getElementById('cy'),minZoom:.2,maxZoom:1.6,wheelSensitivity:.2,
- elements:[...NODES.map(n=>({data:{...n,c:color[n.type]}})),...EDGES.map(e=>({data:e}))],
+ elements:[...NODES.map(n=>({data:{...n,c:color[dimValue(n,dim)]}})),...EDGES.map(e=>({data:e}))],
  style:[
   {selector:'node',style:{'background-color':'data(c)','label':'data(title)','color':'#e6e8ee',
    'font-size':10,'text-wrap':'wrap','text-max-width':120,'text-valign':'bottom','text-margin-y':4,
@@ -265,6 +551,11 @@ const cy=cytoscape({container:document.getElementById('cy'),minZoom:.2,maxZoom:1
    'width':'data(sz)','height':'data(sz)'}},
   {selector:'edge',style:{'width':1.2,'line-color':'#3a4150','target-arrow-color':'#3a4150',
    'target-arrow-shape':'triangle','arrow-scale':.8,'curve-style':'bezier','opacity':.7}},
+  // A derived edge is an inference from frontmatter, not a sentence someone
+  // wrote. Dashing it keeps that difference legible instead of presenting both
+  // as the same kind of claim.
+  {selector:'edge[origin="derived"]',style:{'line-style':'dashed','line-color':'#4b5468',
+   'target-arrow-color':'#4b5468','opacity':.55}},
   {selector:'.dim',style:{'opacity':.10}},{selector:'.hl',style:{'border-width':3,'border-color':'#fff'}}
  ],
  layout:{name:'__LAYOUT__',animate:false,nodeRepulsion:9000,idealEdgeLength:90,padding:40}});
@@ -314,12 +605,56 @@ function resolveHref(cid,href){let t=(href||'').split('#')[0];if(!t.endsWith('.m
    if(seg==='..'){if(!base.length)return null;base.pop();}else base.push(seg);}
   tgt=base.join('/');}
  return byId[tgt]?tgt:null;}
+// marked implements no footnotes, so `[^ref]` survives into the rendered page as
+// literal text — mid-sentence and inside table cells — and the definitions pile
+// up unlabelled at the bottom. Bundles lean on footnotes to carry provenance, so
+// this is most of what makes a concept read badly. Definitions are lifted out,
+// references numbered in order of first appearance, and the list rebuilt at the
+// end with a link back to each call site.
+function renderBody(md){
+ const defs=new Map(),kept=[],lines=(md||'').split('\n');
+ let fence=false;
+ for(let i=0;i<lines.length;i++){
+  if(/^\s*(```|~~~)/.test(lines[i]))fence=!fence;
+  const m=fence?null:lines[i].match(/^\[\^([^\]]+)\]:\s?(.*)$/);
+  if(!m){kept.push(lines[i]);continue;}
+  const parts=[m[2]];
+  // A definition owns the indented lines that follow it.
+  while(i+1<lines.length&&/^(\s{2,}|\t)/.test(lines[i+1])&&lines[i+1].trim())parts.push(lines[++i].trim());
+  defs.set(m[1],parts.join(' ').trim());}
+ if(!defs.size)return marked.parse(kept.join('\n'));
+ const order=[];
+ let fence2=false;
+ const body=kept.map(line=>{
+  if(/^\s*(```|~~~)/.test(line)){fence2=!fence2;return line;}
+  if(fence2)return line;                       // a reference inside code is code
+  return line.replace(/\[\^([^\]]+)\]/g,(all,ref)=>{
+   if(!defs.has(ref))return all;               // an undefined reference stays as written
+   let i=order.indexOf(ref);if(i<0){order.push(ref);i=order.length-1;}
+   return `<sup class="fnref" id="fnref-${i+1}"><a href="#fn-${i+1}">${i+1}</a></sup>`;});
+ }).join('\n');
+ const html=marked.parse(body);
+ if(!order.length)return html;
+ const items=order.map((ref,i)=>
+  `<li id="fn-${i+1}">${marked.parseInline(defs.get(ref))} <a class="fnback" href="#fnref-${i+1}">↩</a></li>`).join('');
+ return html+`<section class="footnotes"><ol>${items}</ol></section>`;}
 function show(id){const n=byId[id];if(!n)return;const c=color[n.type];
  side.innerHTML=`<span class="type" style="background:${c}">${esc(n.type)}</span>
  <h2>${esc(n.title)}</h2><div class="desc">${esc(n.description)||'<span class=empty>no description</span>'}</div>
  <div class="tags">${(n.tags||[]).map(t=>`<span class="tag">${esc(t)}</span>`).join('')}</div>
  ${badges(n)}${metaBlock(n)}${srcList(n)}${relList('Links to',outL[id])}${relList('Cited by',inL[id])}
- <div class="body">${n.body?DOMPurify.sanitize(marked.parse(n.body)):'<span class=empty>empty body</span>'}</div>`;
+ <div class="body">${n.body?DOMPurify.sanitize(renderBody(n.body)):'<span class=empty>empty body</span>'}</div>`;
+ // marked emits a bare <table>; a wide one would stretch the panel and put a
+ // second scrollbar on the page, so each gets its own horizontally-scrolling box.
+ side.querySelectorAll('.body table').forEach(t=>{if(t.parentElement.classList.contains('tw'))return;
+  const w=document.createElement('div');w.className='tw';t.replaceWith(w);w.appendChild(t);});
+ // Footnote jumps scroll the panel directly. Left to the browser they would
+ // rewrite location.hash, which this page uses to name the selected concept —
+ // so a reload after reading a footnote would open nothing.
+ side.querySelectorAll('.fnref a,.fnback').forEach(a=>a.onclick=e=>{
+  e.preventDefault();
+  const t=side.querySelector('#'+CSS.escape(a.getAttribute('href').slice(1)));
+  if(t)t.scrollIntoView({behavior:'smooth',block:'center'});});
  side.querySelectorAll('[data-go]').forEach(a=>a.onclick=()=>select(a.getAttribute('data-go')));
  side.querySelectorAll('.body a[href]').forEach(a=>{const tgt=resolveHref(id,a.getAttribute('href'));
   if(tgt)a.onclick=e=>{e.preventDefault();select(tgt);};});}
@@ -331,8 +666,11 @@ cy.on('tap','node',e=>select(e.target.id()));
 cy.on('tap',e=>{if(e.target===cy)cy.elements().removeClass('dim hl');});
 function applyFilter(){const q=document.getElementById('search').value.toLowerCase();const ty=document.getElementById('type').value;
  cy.batch(()=>cy.nodes().forEach(n=>{const d=n.data();
-  const m=(!q||(d.title+' '+d.type+' '+d.description+' '+(d.tags||[]).join(' ')).toLowerCase().includes(q))
-        &&(!ty||d.type===ty)&&!off.has(d.type);
+  // Extension values join the haystack: a bundle's own identifier (`acme.id`)
+  // is what a reader actually types, and it appears nowhere in title or body.
+  const ext=Object.values(d.ext||{}).join(' ');
+  const m=(!q||(d.title+' '+d.type+' '+d.description+' '+(d.tags||[]).join(' ')+' '+ext).toLowerCase().includes(q))
+        &&(!ty||d.type===ty)&&!off.has(dimValue(d,dim));
   n.style('display',m?'element':'none');}));}
 let debounce;
 document.getElementById('search').oninput=()=>{clearTimeout(debounce);debounce=setTimeout(applyFilter,150);};
@@ -342,9 +680,33 @@ let curLayout='__LAYOUT__';
 document.getElementById('layout').onchange=e=>{const v=e.target.value;
  if(v==='cose'&&NODES.length>__COSEMAX__&&!confirm(`force layout on ${NODES.length} concepts can freeze this tab — run anyway?`)){e.target.value=curLayout;return;}
  curLayout=v;cy.layout({name:v,animate:true,padding:40,nodeRepulsion:9000,idealEdgeLength:90}).run();};
-document.getElementById('legend').innerHTML=types.map(t=>`<span class="chip" data-t="${esc(t)}"><span class="dot" style="background:${color[t]}"></span>${esc(t)} (${NODES.filter(n=>n.type===t).length})</span>`).join('');
-document.querySelectorAll('#legend .chip').forEach(ch=>ch.onclick=()=>{const t=ch.getAttribute('data-t');
- if(off.has(t)){off.delete(t);ch.classList.remove('off');}else{off.add(t);ch.classList.add('off');}applyFilter();});
+function drawLegend(){document.getElementById('legend').innerHTML=buckets.map(b=>
+ `<span class="chip${off.has(b)?' off':''}" data-t="${esc(b)}"><span class="dot" style="background:${color[b]}"></span>${esc(b)} (${NODES.filter(n=>dimValue(n,dim)===b).length})</span>`).join('');
+ document.querySelectorAll('#legend .chip').forEach(ch=>ch.onclick=()=>{const t=ch.getAttribute('data-t');
+  if(off.has(t)){off.delete(t);ch.classList.remove('off');}else{off.add(t);ch.classList.add('off');}applyFilter();});}
+const dimsel=document.getElementById('colorby');
+dims.forEach(d=>{const o=document.createElement('option');o.value=d;
+ o.textContent=d==='type'?'colour: type':`colour: ${d}`;dimsel.appendChild(o);});
+dimsel.onchange=e=>{dim=e.target.value;
+ // The old chips named buckets that no longer exist; carrying their hidden state
+ // over would silently filter the graph by a dimension the reader just left.
+ off.clear();recolour();
+ cy.batch(()=>cy.nodes().forEach(n=>n.data('c',color[dimValue(n.data(),dim)])));
+ drawLegend();applyFilter();};
+drawLegend();
+// With no derived edges there is nothing to toggle, and an inert control that
+// never does anything reads as a broken one.
+const derivedCount=EDGES.filter(e=>e.origin==='derived').length;
+function setDerived(on){cy.batch(()=>cy.edges().forEach(ed=>{
+ if(ed.data('origin')==='derived')ed.style('display',on?'element':'none');}));}
+if(!derivedCount)document.getElementById('derivedbox').style.display='none';
+else{
+ // Off by default. A field like an owning team is the same value on most of the
+ // bundle, so showing it collapses the layout into a few giant stars and buries
+ // the written links underneath. It is a lens to reach for, not the first view.
+ setDerived(false);
+ document.getElementById('derivedbox').title+=` — ${derivedCount} inferred`;
+ document.getElementById('showderived').onchange=e=>setDerived(e.target.checked);}
 document.getElementById('layout').value='__LAYOUT__';
 const Q=new URLSearchParams(location.search),QL=Q.get('layout'),QS=Q.get('select');
 if(QL&&[...document.querySelectorAll('#layout option')].some(o=>o.value===QL)){document.getElementById('layout').value=QL;curLayout=QL;cy.layout({name:QL,animate:false,padding:40,nodeRepulsion:9000,idealEdgeLength:90}).run();}
@@ -356,8 +718,11 @@ if(QS&&byId[QS])select(QS);else fromHash();
 
 def render(bundle: Path, out: Path, title: str | None = None, link: str | None = None,
            layout: str | None = None, og_image: str | None = None,
-           max_nodes: int | None = None):
-    nodes, edges = build(bundle)
+           max_nodes: int | None = None, derivations=(), vendor: bool = False,
+           report: bool = False, body_max: int = BODY_MAX):
+    nodes, edges, audit = build(bundle, derivations, body_max)
+    if report:
+        print_report(nodes, edges, audit)
     if max_nodes is not None and len(nodes) > max_nodes:
         sys.exit(f"error: {len(nodes)} concepts exceeds --max-nodes {max_nodes}")
     if layout is None:
@@ -377,7 +742,9 @@ def render(bundle: Path, out: Path, title: str | None = None, link: str | None =
     og_desc = aesc(f"{len(nodes)} concepts · interactive Open Knowledge Format knowledge graph")
     og_img = (f'<meta property="og:image" content="{aesc(og_image)}">\n'
               f'<meta name="twitter:image" content="{aesc(og_image)}">') if og_image else ""
-    subs = {"__NAME__": name, "__LINK__": src, "__LAYOUT__": layout,
+    libs = vendor_libs(out.resolve().parent / ".okf-vendor") if vendor else CDN_TAGS
+    subs = {"__LIBS__": libs,
+            "__NAME__": name, "__LINK__": src, "__LAYOUT__": layout,
             "__COSEMAX__": str(AUTO_COSE_MAX),
             "__OGTITLE__": og_title, "__OGDESC__": og_desc, "__OGIMAGE__": og_img,
             "__N__": str(len(nodes)), "__E__": str(len(edges)),
@@ -417,13 +784,36 @@ def main() -> int:
                     help="refuse to render bundles with more concepts than this (useful in CI)")
     ap.add_argument("--og-image", default=None,
                     help="absolute URL for the social-preview image (og:image / twitter:image)")
+    ap.add_argument("--derive-edge", action="append", default=[], metavar="FIELD=PATTERN",
+                    help="treat a frontmatter field as a reference to another concept, e.g. "
+                         "--derive-edge acme.owner_team=team-{} maps `infra` to the concept whose "
+                         "identifier is `team-infra`. Values that already equal an identifier are "
+                         "linked automatically and need no pattern. Repeatable.")
+    ap.add_argument("--vendor", action="store_true",
+                    help="inline cytoscape/marked/dompurify instead of loading them from a CDN, "
+                         "so the page works offline and under a strict CSP")
+    ap.add_argument("--report", action="store_true",
+                    help="print bundle health to stderr: orphans, broken links, stale, drafts")
+    ap.add_argument("--max-body", type=int, default=BODY_MAX, metavar="CHARS",
+                    help=f"characters of each concept body to embed (default {BODY_MAX:,}); "
+                         "a truncated body says so in the panel")
     args = ap.parse_args()
     if not args.bundle.is_dir():
         print(f"error: {args.bundle} is not a directory", file=sys.stderr)
         return 2
     out = args.out or (args.bundle / "viz.html")
+    derivations = []
+    for spec in args.derive_edge:
+        field, sep, pattern = spec.partition("=")
+        if not sep or "{}" not in pattern:
+            print(f"error: --derive-edge expects FIELD=PATTERN with a {{}} placeholder, got {spec!r}",
+                  file=sys.stderr)
+            return 2
+        derivations.append((field.strip(), pattern.strip()))
     n, e = render(args.bundle, out, title=args.title, link=args.link, layout=args.layout,
-                  og_image=args.og_image, max_nodes=args.max_nodes)
+                  og_image=args.og_image, max_nodes=args.max_nodes,
+                  derivations=derivations, vendor=args.vendor, report=args.report,
+                  body_max=args.max_body)
     print(f"rendered {n} concepts, {e} links -> {out}")
     return 0
 


### PR DESCRIPTION
## What

Four changes to `skills/visualize`, all driven by rendering a real 166-concept v0.2 bundle:

**1. Producer-defined frontmatter reaches the page.** §4.1 says producers MAY add any keys and consumers SHOULD preserve them, but the node payload carried only the reserved vocabulary — so a bundle could be coloured by `type` and nothing else. Non-reserved keys are now flattened to dotted scalar paths (`acme: {owner_team: infra}` → `acme.owner_team`) and shipped with each node.

A `colour:` picker offers any field that actually partitions the bundle — between 2 and 24 distinct values. One value paints every node identically; a value per node (an id, a URL) is N colours and no signal. Legend and filtering follow the selected field. Extension values also join the search index, so a concept is findable by its own identifier, which otherwise appears nowhere in title or body.

**2. `--derive-edge FIELD=PATTERN`.** A field whose value names another concept becomes an edge. Values that already equal an identifier are linked automatically; the pattern form covers joins like `owner_team: infra` → `team-infra`. Derived edges are drawn dashed and default to hidden — an inference is not a sentence someone wrote, and a field shared by most of the bundle collapses the layout into a few giant stars. The identifier field is discovered (present on every concept, unique across all of them) rather than configured, so no producer's spelling is baked in.

**3. Footnotes.** `marked` implements none, so `[^ref]` survived into the page as literal text mid-sentence and inside table cells, with the definitions piling up unlabelled at the bottom. In the bundle I tested that is 1308 markers across 96 of 183 concepts. Definitions are now lifted out, references numbered by first appearance, and the list rebuilt with a link back to each call site. References inside fenced code are left alone; a reference with no definition stays as written rather than linking to a footnote that does not exist.

Related: the body cap was 8 000 characters, which silently truncated the longest concepts — and since definitions sit at the bottom, exactly the documents that cite most lost every citation. Raised to 200 000 (`--max-body`), and a truncated body now says so.

**4. `--vendor` and `--report`.** The page described itself as self-contained while fetching three scripts from a CDN at open time, which fails offline, under a strict CSP, and the day a version is unpublished. `--vendor` inlines them (~700 KB, cached). `--report` prints orphans, broken links, undefined footnote references, past-`stale_after` and drafts to stderr.

Broken-link detection is answered against the filesystem rather than the node list, because the two disagree in ways that read as defects but are not: `index.md` is a real file deliberately excluded from the graph, and an external `https://…/notes.md` merely ends in `.md`.

## Why these and not others

Everything here is derived from frontmatter that already exists. No new vocabulary is proposed or required — §6.1 is explicit that link kinds live in prose, and inventing a `relations:` key would put this tool ahead of a spec discussion that is still open.

## Evidence

Rendered against a 166-concept bundle: 120 written edges, 145 derived, 0 broken links (matching that repo's own link test), 18 orphans, 1 genuinely undefined footnote reference.

Footnote rendering was swept across all 166 concepts in jsdom: 0 exceptions, 999 call sites and 303 definitions rendered, and the only unresolved `[^ref]` is the one the source never defines. Layout was checked at 1700px and 1100px for overlap and horizontal overflow.

## Notes

- Two commits: the feature, then a layout fix for the control bar, which had been centred on the viewport and slid under the side panel once a fifth control was added.
- No tests added — `tests/` currently covers `validate` only, so there was no visualize suite to extend. Happy to add one if you'd like a particular shape.
- Existing CDN `<script>` tags are moved verbatim into a constant, not modified; `--vendor` is the path that removes the dependency.
